### PR TITLE
ovsnl: add ovsh.Header byte functions, correct Datapath.List data

### DIFF
--- a/ovsnl/client.go
+++ b/ovsnl/client.go
@@ -125,3 +125,20 @@ func (c *Client) initFamily(f genetlink.Family) error {
 
 	return fmt.Errorf("unrecognized OVS generic netlink family: %q", f.Name)
 }
+
+// headerBytes converts an ovsh.Header into a byte slice.
+func headerBytes(h ovsh.Header) []byte {
+	b := *(*[sizeofHeader]byte)(unsafe.Pointer(&h))
+	return b[:]
+}
+
+// parseHeader converts a byte slice into ovsh.Header.
+func parseHeader(b []byte) (ovsh.Header, error) {
+	// Verify that the byte slice is long enough before doing unsafe casts.
+	if l := len(b); l < sizeofHeader {
+		return ovsh.Header{}, fmt.Errorf("not enough data for OVS message header: %d bytes", l)
+	}
+
+	h := *(*ovsh.Header)(unsafe.Pointer(&b[:sizeofHeader][0]))
+	return h, nil
+}

--- a/ovsnl/datapath_linux_test.go
+++ b/ovsnl/datapath_linux_test.go
@@ -135,7 +135,13 @@ func TestClientDatapathListOK(t *testing.T) {
 		if diff := cmp.Diff(ovsh.DpCmdGet, int(greq.Header.Command)); diff != "" {
 			t.Fatalf("unexpected generic netlink command (-want +got):\n%s", diff)
 		}
-		if diff := cmp.Diff(0, int(nlenc.Uint32(greq.Data))); diff != "" {
+
+		h, err := parseHeader(greq.Data)
+		if err != nil {
+			t.Fatalf("failed to parse OvS generic netlink header: %v", err)
+		}
+
+		if diff := cmp.Diff(0, int(h.Ifindex)); diff != "" {
 			t.Fatalf("unexpected datapath ID (-want +got):\n%s", diff)
 		}
 
@@ -171,7 +177,7 @@ func mustMarshalDatapath(dp Datapath) []byte {
 		Ifindex: int32(dp.Index),
 	}
 
-	hb := *(*[sizeofHeader]byte)(unsafe.Pointer(&h))
+	hb := headerBytes(h)
 
 	s := ovsh.DPStats{
 		Hit:    dp.Stats.Hit,


### PR DESCRIPTION
I realized that the `Datapath.List` query was only working coincidentally because a `uint32` and an `ovsh.Header` occupy the same size in memory.  This is the correct version, although it is functionally equivalent.