### PR TITLE
 ovsdb: add internal receive loop for notifications and callbacks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ script:
   - staticcheck ./...
   - ./scripts/golint.sh
   - go test -race ./...
-  - go test -c ./ovsdb
+  - go test -c -race ./ovsdb
   - sudo ./ovsdb.test -test.v

--- a/ovsdb/client.go
+++ b/ovsdb/client.go
@@ -18,8 +18,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net"
+	"strings"
+	"sync"
+	"sync/atomic"
 
 	"github.com/digitalocean/go-openvswitch/ovsdb/internal/jsonrpc"
 )
@@ -28,6 +32,20 @@ import (
 type Client struct {
 	c  *jsonrpc.Conn
 	ll *log.Logger
+
+	// Incremented atomically when sending RPCs.
+	rpcID *int64
+
+	// Callbacks for RPC responses.
+	cbMu      sync.RWMutex
+	callbacks map[int]chan rpcResponse
+
+	wg *sync.WaitGroup
+}
+
+type rpcResponse struct {
+	Result json.RawMessage
+	Error  error
 }
 
 // An OptionFunc is a function which can configure a Client.
@@ -60,14 +78,41 @@ func New(conn net.Conn, options ...OptionFunc) (*Client, error) {
 		}
 	}
 
+	// Set up RPC request IDs.
+	var rpcID int64
+	client.rpcID = &rpcID
+
+	// Set up the JSON-RPC connection.
 	client.c = jsonrpc.NewConn(conn, client.ll)
+
+	// Set up callbacks.
+	client.callbacks = make(map[int]chan rpcResponse)
+
+	// Start up any background routines.
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// Handle all incoming RPC responses and notifications.
+	go func() {
+		defer wg.Done()
+		client.listen()
+	}()
+
+	client.wg = &wg
 
 	return client, nil
 }
 
+// requestID returns the next available request ID for an RPC.
+func (c *Client) requestID() int {
+	return int(atomic.AddInt64(c.rpcID, 1))
+}
+
 // Close closes a Client's connection.
 func (c *Client) Close() error {
-	return c.c.Close()
+	err := c.c.Close()
+	c.wg.Wait()
+	return err
 }
 
 // ListDatabases returns the name of all databases known to the OVSDB server.
@@ -82,6 +127,11 @@ func (c *Client) ListDatabases() ([]string, error) {
 
 // rpc performs a single RPC request, and checks the response for errors.
 func (c *Client) rpc(method string, out interface{}, args ...interface{}) error {
+	// Unmarshal results into empty struct if no out specified.
+	if out == nil {
+		out = &struct{}{}
+	}
+
 	// Captures any OVSDB errors.
 	r := result{
 		Reply: out,
@@ -90,10 +140,24 @@ func (c *Client) rpc(method string, out interface{}, args ...interface{}) error 
 	req := jsonrpc.Request{
 		Method: method,
 		Params: args,
-		// Let the client handle the request ID.
+		ID:     c.requestID(),
 	}
 
-	if err := c.c.Execute(req, &r); err != nil {
+	// Add callback for this RPC ID to return results via channel.
+	ch := make(chan rpcResponse, 0)
+	c.addCallback(req.ID, ch)
+
+	if err := c.c.Send(req); err != nil {
+		return err
+	}
+
+	// Wait for callback to fire.
+	res := <-ch
+	if err := res.Error; err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(res.Result, &r); err != nil {
 		return err
 	}
 
@@ -103,6 +167,70 @@ func (c *Client) rpc(method string, out interface{}, args ...interface{}) error 
 	}
 
 	return nil
+}
+
+// listen starts an RPC receive loop that can return RPC results to
+// clients via a callback.
+func (c *Client) listen() {
+	for {
+		res, err := c.c.Receive()
+		if err != nil {
+			// EOF or closed connection means time to stop serving.
+			if err == io.EOF || strings.Contains(err.Error(), "use of closed network") {
+				return
+			}
+
+			// For any other connection errors, just keep trying.
+			continue
+		}
+
+		// TODO(mdlayher): deal with RPC notifications.
+
+		// Handle any JSON-RPC top-level errors.
+		if err := res.Err(); err != nil {
+			c.doCallback(*res.ID, rpcResponse{
+				Error: err,
+			})
+			continue
+		}
+
+		// Return RPC results via callback.
+		c.doCallback(*res.ID, rpcResponse{
+			Result: res.Result,
+		})
+	}
+}
+
+// addCallback registers a callback for an RPC response for the specified ID,
+// and accepts a channel to return the results on.
+func (c *Client) addCallback(id int, ch chan rpcResponse) {
+	c.cbMu.Lock()
+	defer c.cbMu.Unlock()
+
+	if _, ok := c.callbacks[id]; ok {
+		// This ID was already registered.
+		panicf("OVSDB callback with ID %d already registered", id)
+	}
+
+	c.callbacks[id] = ch
+}
+
+// doCallback performs a callback for an RPC response and clears the
+// callback on completion.
+func (c *Client) doCallback(id int, res rpcResponse) {
+	c.cbMu.Lock()
+	defer c.cbMu.Unlock()
+
+	ch, ok := c.callbacks[id]
+	if !ok {
+		// Nobody is listening to this callback.
+		panicf("OVSDB callback with ID %d has no listeners", id)
+	}
+
+	// Return result, clean up channel, and remove this callback.
+	ch <- res
+	close(ch)
+	delete(c.callbacks, id)
 }
 
 // A result is used to unmarshal JSON-RPC results, and to check for any errors.
@@ -142,4 +270,8 @@ type Error struct {
 
 func (e *Error) Error() string {
 	return fmt.Sprintf("%s: %s: %s", e.Err, e.Details, e.Syntax)
+}
+
+func panicf(format string, a ...interface{}) {
+	panic(fmt.Sprintf(format, a...))
 }

--- a/ovsdb/internal/jsonrpc/conn_test.go
+++ b/ovsdb/internal/jsonrpc/conn_test.go
@@ -15,41 +15,43 @@
 package jsonrpc_test
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"testing"
 
 	"github.com/digitalocean/go-openvswitch/ovsdb/internal/jsonrpc"
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestConnExecuteBadSequence(t *testing.T) {
-	req := jsonrpc.Request{
-		ID:     10,
-		Method: "test",
-	}
-
-	c, done := jsonrpc.TestConn(t, func(_ jsonrpc.Request) jsonrpc.Response {
-		return jsonrpc.Response{
-			// Bad sequence.
-			ID: 1,
-		}
-	})
+func TestConnSendNoRequestID(t *testing.T) {
+	c, _, done := jsonrpc.TestConn(t, nil)
 	defer done()
 
-	if err := c.Execute(req, nil); err == nil {
+	if err := c.Send(jsonrpc.Request{}); err == nil {
 		t.Fatal("expected an error, but none occurred")
 	}
 }
 
-func TestConnExecuteError(t *testing.T) {
+func TestConnReceiveEOF(t *testing.T) {
+	c := jsonrpc.NewConn(&eofReadWriteCloser{}, nil)
+
+	// Conn should not mask io.EOF.
+	_, err := c.Receive()
+	if err != io.EOF {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConnSendReceiveError(t *testing.T) {
 	// TODO(mdlayher): what does this actually look like?
 	type rpcError struct {
 		Details string
 	}
 
-	c, done := jsonrpc.TestConn(t, func(_ jsonrpc.Request) jsonrpc.Response {
+	c, _, done := jsonrpc.TestConn(t, func(_ jsonrpc.Request) jsonrpc.Response {
 		return jsonrpc.Response{
-			ID: 10,
+			ID: intPtr(10),
 			Error: rpcError{
 				Details: "some error",
 			},
@@ -57,15 +59,25 @@ func TestConnExecuteError(t *testing.T) {
 	})
 	defer done()
 
-	if err := c.Execute(jsonrpc.Request{ID: 10}, nil); err == nil {
+	if err := c.Send(jsonrpc.Request{ID: 10}); err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+
+	res, err := c.Receive()
+	if err != nil {
+		t.Fatalf("failed to receive response: %v", err)
+	}
+
+	if err := res.Err(); err == nil {
 		t.Fatal("expected an error, but none occurred")
 	}
 }
 
-func TestConnExecuteOK(t *testing.T) {
+func TestConnSendReceiveOK(t *testing.T) {
 	req := jsonrpc.Request{
 		Method: "hello",
 		Params: []interface{}{"world"},
+		ID:     1,
 	}
 
 	type message struct {
@@ -76,23 +88,34 @@ func TestConnExecuteOK(t *testing.T) {
 		Message: "hello world",
 	}
 
-	c, done := jsonrpc.TestConn(t, func(got jsonrpc.Request) jsonrpc.Response {
-		req.ID = 1
-
+	c, _, done := jsonrpc.TestConn(t, func(got jsonrpc.Request) jsonrpc.Response {
 		if diff := cmp.Diff(req, got); diff != "" {
 			panicf("unexpected request (-want +got):\n%s", diff)
 		}
 
 		return jsonrpc.Response{
-			ID:     1,
-			Result: want,
+			ID:     intPtr(1),
+			Result: mustMarshalJSON(t, want),
 		}
 	})
 	defer done()
 
+	if err := c.Send(req); err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+
+	res, err := c.Receive()
+	if err != nil {
+		t.Fatalf("failed to receive response: %v", err)
+	}
+
+	if err := res.Err(); err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+
 	var out message
-	if err := c.Execute(req, &out); err != nil {
-		t.Fatalf("failed to execute: %v", err)
+	if err := json.Unmarshal(res.Result, &out); err != nil {
+		t.Fatalf("failed to unmarshal JSON: %v", err)
 	}
 
 	if diff := cmp.Diff(want, out); diff != "" {
@@ -100,6 +123,93 @@ func TestConnExecuteOK(t *testing.T) {
 	}
 }
 
+func TestConnSendReceiveNotificationsOK(t *testing.T) {
+	const id = 10
+
+	req := jsonrpc.Request{
+		ID:     id,
+		Method: "monitor",
+		Params: []interface{}{"Open_vSwitch"},
+	}
+
+	res := jsonrpc.Response{
+		ID:     intPtr(id),
+		Result: mustMarshalJSON(t, "some bytes"),
+	}
+
+	c, notifC, done := jsonrpc.TestConn(t, func(got jsonrpc.Request) jsonrpc.Response {
+		if diff := cmp.Diff(req, got); diff != "" {
+			panicf("unexpected request (-want +got):\n%s", diff)
+		}
+
+		return res
+	})
+	defer done()
+
+	note := &jsonrpc.Response{
+		Method: "notify",
+	}
+	notifC <- note
+	notifC <- note
+
+	if err := c.Send(req); err != nil {
+		t.Fatalf("failed to send request: %v", err)
+	}
+
+	var responses, notes int
+	for i := 0; i < 3; i++ {
+		res, err := c.Receive()
+		if err != nil {
+			t.Fatalf("failed to receive response: %v", err)
+		}
+
+		if res.ID != nil {
+			responses++
+			if diff := cmp.Diff(req.ID, *res.ID); diff != "" {
+				t.Fatalf("unexpected response request ID (-want +got):\n%s", diff)
+			}
+
+			continue
+		}
+
+		notes++
+		if diff := cmp.Diff(note.Method, res.Method); diff != "" {
+			t.Fatalf("unexpected notification method (-want +got):\n%s", diff)
+		}
+	}
+
+	if diff := cmp.Diff(1, responses); diff != "" {
+		t.Fatalf("unexpected number of responses (-want +got):\n%s", diff)
+	}
+
+	if diff := cmp.Diff(2, notes); diff != "" {
+		t.Fatalf("unexpected number of notifications (-want +got):\n%s", diff)
+	}
+}
+
+func mustMarshalJSON(t *testing.T, v interface{}) []byte {
+	t.Helper()
+
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal JSON: %v", err)
+	}
+
+	return b
+}
+
+func intPtr(i int) *int {
+	return &i
+}
+
 func panicf(format string, a ...interface{}) {
 	panic(fmt.Sprintf(format, a...))
+}
+
+type eofReadWriteCloser struct {
+	io.ReadWriteCloser
+}
+
+func (rwc *eofReadWriteCloser) Read(b []byte) (int, error) {
+	return 0, io.EOF
 }


### PR DESCRIPTION
- Sets up `jsonrpc` so that we can do callbacks in `ovsdb.Client` for RPC responses and notifications pushed from the server.
- Sets up a receive loop in `ovsdb` and uses it for standard RPCs.
- Adds a lot of tests to ensure that no race conditions or improper shutdowns occur.