### PR TITLE
ovsdb: don't crash on unhandled callback RPC

### DIFF
--- a/ovsdb/client.go
+++ b/ovsdb/client.go
@@ -213,7 +213,7 @@ func (c *Client) doCallback(id int, res rpcResponse) {
 	ch, ok := c.callbacks[id]
 	if !ok {
 		// Nobody is listening to this callback.
-		panicf("OVSDB callback with ID %d has no listeners", id)
+		return
 	}
 
 	// Return result, clean up channel, and remove this callback.


### PR DESCRIPTION
In a real world scenario, it's totally possible that our client could receive some request that it can't handle, causing it to crash.  Let's just no-op these.