### PR TITLE
 ovsdb: add ClientStats, fix callback leak

### DIFF
--- a/ovsdb/client.go
+++ b/ovsdb/client.go
@@ -109,6 +109,28 @@ func (c *Client) Close() error {
 	return err
 }
 
+// Stats returns a ClientStats with current statistics for the Cient.
+func (c *Client) Stats() ClientStats {
+	var s ClientStats
+
+	c.cbMu.RLock()
+	defer c.cbMu.RUnlock()
+
+	s.Callbacks.Current = len(c.callbacks)
+
+	return s
+}
+
+// ClientStats contains statistics about a Client.
+type ClientStats struct {
+	// Statistics about the Client's internal callbacks.
+	Callbacks struct {
+		// The number of callback hooks currently registered and waiting
+		// for RPC responses.
+		Current int
+	}
+}
+
 // rpc performs a single RPC request, and checks the response for errors.
 func (c *Client) rpc(ctx context.Context, method string, out interface{}, args ...interface{}) error {
 	// Was the context canceled before sending the RPC?


### PR DESCRIPTION
Could be used as a basis for future metrics and such.

The test shows that the callback leak is now fixed.  I didn't add a new method because it seemed easy enough to do it all in the rpc method.  If I had made a new one, I would have had to release the callback mutex in doCallback, and then re-acquire it to delete the finished callback, which seems inherently race condition prone.