### PR TITLE
ovsdb: change IDs to strings in preparation for echo replies

### DIFF
--- a/ovsdb/internal/jsonrpc/conn.go
+++ b/ovsdb/internal/jsonrpc/conn.go
@@ -25,7 +25,7 @@ import (
 
 // A Request is a JSON-RPC request.
 type Request struct {
-	ID     int           `json:"id"`
+	ID     string        `json:"id"`
 	Method string        `json:"method"`
 	Params []interface{} `json:"params"`
 }
@@ -33,7 +33,7 @@ type Request struct {
 // A Response is either a JSON-RPC response, or a JSON-RPC request notification.
 type Response struct {
 	// Non-null for response; null for request notification.
-	ID *int `json:"id"`
+	ID *string `json:"id"`
 
 	// Response fields.
 	Result json.RawMessage `json:"result,omitempty"`
@@ -91,8 +91,8 @@ func (c *Conn) Close() error {
 
 // Send sends a single JSON-RPC request.
 func (c *Conn) Send(req Request) error {
-	if req.ID == 0 {
-		return errors.New("JSON-RPC request ID must be non-zero")
+	if req.ID == "" {
+		return errors.New("JSON-RPC request ID must not be empty")
 	}
 
 	// Non-nil array required for ovsdb-server to reply.

--- a/ovsdb/internal/jsonrpc/conn_test.go
+++ b/ovsdb/internal/jsonrpc/conn_test.go
@@ -51,7 +51,7 @@ func TestConnSendReceiveError(t *testing.T) {
 
 	c, _, done := jsonrpc.TestConn(t, func(_ jsonrpc.Request) jsonrpc.Response {
 		return jsonrpc.Response{
-			ID: intPtr(10),
+			ID: strPtr("10"),
 			Error: rpcError{
 				Details: "some error",
 			},
@@ -59,7 +59,7 @@ func TestConnSendReceiveError(t *testing.T) {
 	})
 	defer done()
 
-	if err := c.Send(jsonrpc.Request{ID: 10}); err != nil {
+	if err := c.Send(jsonrpc.Request{ID: "10"}); err != nil {
 		t.Fatalf("failed to send request: %v", err)
 	}
 
@@ -77,7 +77,7 @@ func TestConnSendReceiveOK(t *testing.T) {
 	req := jsonrpc.Request{
 		Method: "hello",
 		Params: []interface{}{"world"},
-		ID:     1,
+		ID:     "1",
 	}
 
 	type message struct {
@@ -94,7 +94,7 @@ func TestConnSendReceiveOK(t *testing.T) {
 		}
 
 		return jsonrpc.Response{
-			ID:     intPtr(1),
+			ID:     strPtr("1"),
 			Result: mustMarshalJSON(t, want),
 		}
 	})
@@ -124,7 +124,7 @@ func TestConnSendReceiveOK(t *testing.T) {
 }
 
 func TestConnSendReceiveNotificationsOK(t *testing.T) {
-	const id = 10
+	const id = "10"
 
 	req := jsonrpc.Request{
 		ID:     id,
@@ -133,7 +133,7 @@ func TestConnSendReceiveNotificationsOK(t *testing.T) {
 	}
 
 	res := jsonrpc.Response{
-		ID:     intPtr(id),
+		ID:     strPtr(id),
 		Result: mustMarshalJSON(t, "some bytes"),
 	}
 
@@ -198,8 +198,8 @@ func mustMarshalJSON(t *testing.T, v interface{}) []byte {
 	return b
 }
 
-func intPtr(i int) *int {
-	return &i
+func strPtr(s string) *string {
+	return &s
 }
 
 func panicf(format string, a ...interface{}) {

--- a/ovsdb/rpc_test.go
+++ b/ovsdb/rpc_test.go
@@ -35,7 +35,7 @@ func TestClientListDatabases(t *testing.T) {
 		}
 
 		return jsonrpc.Response{
-			ID:     intPtr(1),
+			ID:     strPtr("1"),
 			Result: mustMarshalJSON(t, want),
 		}
 	})
@@ -54,7 +54,7 @@ func TestClientListDatabases(t *testing.T) {
 func TestClientEchoError(t *testing.T) {
 	c, _, done := testClient(t, func(req jsonrpc.Request) jsonrpc.Response {
 		return jsonrpc.Response{
-			ID:     intPtr(1),
+			ID:     strPtr("1"),
 			Result: mustMarshalJSON(t, []string{"foo"}),
 		}
 	})
@@ -78,7 +78,7 @@ func TestClientEchoOK(t *testing.T) {
 		}
 
 		return jsonrpc.Response{
-			ID:     intPtr(1),
+			ID:     strPtr("1"),
 			Result: mustMarshalJSON(t, []string{echo}),
 		}
 	})


### PR DESCRIPTION
ovsdb-server sends some string IDs our way if we talk to it over TCP:
```
[zsh|matt@nerr-2]:~ 0 % telnet localhost 6632   
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
{"method":"echo","id":"echo","params":[]}Connection closed by foreign host.
```

This prepares us for dealing with those in the receive loop.