### PR TITLE
ovsdb: make params an interface for more type flexibility

### DIFF
--- a/ovsdb/client.go
+++ b/ovsdb/client.go
@@ -200,7 +200,7 @@ type ClientStats struct {
 }
 
 // rpc performs a single RPC request, and checks the response for errors.
-func (c *Client) rpc(ctx context.Context, method string, out interface{}, args ...interface{}) error {
+func (c *Client) rpc(ctx context.Context, method string, out, arg interface{}) error {
 	// Was the context canceled before sending the RPC?
 	select {
 	case <-ctx.Done():
@@ -218,7 +218,7 @@ func (c *Client) rpc(ctx context.Context, method string, out interface{}, args .
 
 	req := jsonrpc.Request{
 		Method: method,
-		Params: args,
+		Params: arg,
 		ID:     c.requestID(),
 	}
 

--- a/ovsdb/internal/jsonrpc/conn.go
+++ b/ovsdb/internal/jsonrpc/conn.go
@@ -25,9 +25,9 @@ import (
 
 // A Request is a JSON-RPC request.
 type Request struct {
-	ID     string        `json:"id"`
-	Method string        `json:"method"`
-	Params []interface{} `json:"params"`
+	ID     string      `json:"id"`
+	Method string      `json:"method"`
+	Params interface{} `json:"params"`
 }
 
 // A Response is either a JSON-RPC response, or a JSON-RPC request notification.

--- a/ovsdb/rpc.go
+++ b/ovsdb/rpc.go
@@ -22,7 +22,7 @@ import (
 // ListDatabases returns the name of all databases known to the OVSDB server.
 func (c *Client) ListDatabases(ctx context.Context) ([]string, error) {
 	var dbs []string
-	if err := c.rpc(ctx, "list_dbs", &dbs); err != nil {
+	if err := c.rpc(ctx, "list_dbs", &dbs, nil); err != nil {
 		return nil, err
 	}
 
@@ -32,14 +32,14 @@ func (c *Client) ListDatabases(ctx context.Context) ([]string, error) {
 // Echo verifies that the OVSDB connection is alive, and can be used to keep
 // the connection alive.
 func (c *Client) Echo(ctx context.Context) error {
-	const req = "github.com/digitalocean/go-openvswitch/ovsdb"
+	req := [1]string{"github.com/digitalocean/go-openvswitch/ovsdb"}
 
 	var res [1]string
 	if err := c.rpc(ctx, "echo", &res, req); err != nil {
 		return err
 	}
 
-	if res[0] != req {
+	if res[0] != req[0] {
 		return fmt.Errorf("invalid echo response: %q", res[0])
 	}
 

--- a/ovsdb/rpc_test.go
+++ b/ovsdb/rpc_test.go
@@ -30,7 +30,10 @@ func TestClientListDatabases(t *testing.T) {
 			panicf("unexpected RPC method (-want +got):\n%s", diff)
 		}
 
-		if diff := cmp.Diff(0, len(req.Params)); diff != "" {
+		// Client should send an empty array parameter.
+		ps := req.Params.([]interface{})
+
+		if diff := cmp.Diff(0, len(ps)); diff != "" {
 			panicf("unexpected number of RPC parameters (-want +got):\n%s", diff)
 		}
 


### PR DESCRIPTION
Some RPCs use really weird requests, e.g.

```
write: {"id":"1","method":"transact","params":["Open_vSwitch",{"op":"select","table":"Bridge","where":[["name","==","ovsbr0"]]}]}
 read: {"id":"1","result":[{"rows":[{"name":"ovsbr0","flood_vlans":["set",[]],"netflow":["set",[]],"mirrors":["set",[]],"_uuid":["uuid","4bd512ea-5c3b-488d-b4dc-305f38911210"],"status":["map",[]],"datapath_id":"0000ea12d54b8d48","controller":["set",[]],"_version":["uuid","4ff1a3db-83eb-4df3-a8cb-2366d4a85af0"],"ipfix":["set",[]],"protocols":["set",[]],"fail_mode":["set",[]],"ports":["uuid","003fd088-02b9-406f-9894-19ec15d4da13"],"flow_tables":["map",[]],"other_config":["map",[]],"datapath_type":"","sflow":["set",[
 read: ]],"external_ids":["map",[]],"stp_enable":false}]}],"error":null}
```

We need the flexibility of empty interface on its own or otherwise that params array gets nested in a second one.