### PR TITLE
ovs: simplify hex parsing

### DIFF
--- a/ovs/matchparser.go
+++ b/ovs/matchparser.go
@@ -16,8 +16,6 @@ package ovs
 
 import (
 	"bytes"
-	"encoding/binary"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -302,41 +300,25 @@ func parseTunID(value string) (Match, error) {
 	}
 }
 
-// pareHexUint16 parses a uint16 value from a hexadecimal string.
+// parseHexUint16 parses a uint16 value from a hexadecimal string.
 func parseHexUint16(value string) (uint16, error) {
-	b, err := hex.DecodeString(strings.TrimPrefix(value, hexPrefix))
+	val, err := strconv.ParseUint(strings.TrimPrefix(value, hexPrefix), 16, 32)
 	if err != nil {
 		return 0, err
 	}
-	if len(b) != 2 {
-		return 0, errors.New("hexadecimal value must be two bytes in length")
-	}
-
-	return binary.BigEndian.Uint16(b), nil
+	return uint16(val), nil
 }
 
-// pareHexUint32 parses a uint32 value from a hexadecimal string.
+// parseHexUint32 parses a uint32 value from a hexadecimal string.
 func parseHexUint32(value string) (uint32, error) {
-	b, err := hex.DecodeString(strings.TrimPrefix(value, hexPrefix))
+	val, err := strconv.ParseUint(strings.TrimPrefix(value, hexPrefix), 16, 32)
 	if err != nil {
 		return 0, err
 	}
-	if len(b) != 4 {
-		return 0, errors.New("hexadecimal value must be four bytes in length")
-	}
-
-	return binary.BigEndian.Uint32(b), nil
+	return uint32(val), nil
 }
 
-// pareHexUint64 parses a uint64 value from a hexadecimal string.
+// parseHexUint64 parses a uint64 value from a hexadecimal string.
 func parseHexUint64(value string) (uint64, error) {
-	b, err := hex.DecodeString(strings.TrimPrefix(value, hexPrefix))
-	if err != nil {
-		return 0, err
-	}
-	if len(b) != 8 {
-		return 0, errors.New("hexadecimal value must be eight bytes in length")
-	}
-
-	return binary.BigEndian.Uint64(b), nil
+	return strconv.ParseUint(strings.TrimPrefix(value, hexPrefix), 16, 64)
 }

--- a/ovs/matchparser_test.go
+++ b/ovs/matchparser_test.go
@@ -274,6 +274,10 @@ func Test_parseMatch(t *testing.T) {
 			m:     TunnelID(1),
 		},
 		{
+			s: "tun_id=0x135d",
+			m: TunnelID(4957),
+		},
+		{
 			s:     "tun_id=0x000000000000000a",
 			final: "tun_id=0xa",
 			m:     TunnelID(10),


### PR DESCRIPTION
Ran into this because I was hitting:

```
    STDERR: netconfig> 2018/02/05 21:40:08 failed to configure private underlay: resource list(Flows(br0)): hexadecimal value must be eight bytes in length
```

On a tun_id= 0x135d

Seemed like we were being overly finicky here - just used stdlib.

@mdlayher @keinohguchi 