### PR TITLE
ovs: correctly parse port only resubmit

### DIFF
--- a/ovs/action.go
+++ b/ovs/action.go
@@ -149,7 +149,8 @@ const (
 	patModTransportSourcePort      = "mod_tp_src:%d"
 	patModVLANVID                  = "mod_vlan_vid:%d"
 	patOutput                      = "output:%d"
-	patResubmit                    = "resubmit(%s,%s)"
+	patResubmitPort                = "resubmit:%s"
+	patResubmitPortTable           = "resubmit(%s,%s)"
 )
 
 // ConnectionTracking sends a packet through the host's connection tracker.
@@ -398,9 +399,10 @@ func (a *resubmitAction) MarshalText() ([]byte, error) {
 	t := ""
 	if a.table != 0 {
 		t = strconv.Itoa(a.table)
+		return bprintf(patResubmitPortTable, p, t), nil
 	}
 
-	return bprintf(patResubmit, p, t), nil
+	return bprintf(patResubmitPort, p), nil
 }
 
 // GoString implements Action.

--- a/ovs/action_test.go
+++ b/ovs/action_test.go
@@ -344,7 +344,7 @@ func TestActionResubmit(t *testing.T) {
 		{
 			desc:   "table zero",
 			port:   1,
-			action: "resubmit(1,)",
+			action: "resubmit:1",
 		},
 		{
 			desc:   "both port and table non-zero",

--- a/ovs/actionparser_test.go
+++ b/ovs/actionparser_test.go
@@ -93,6 +93,7 @@ func Test_parseAction(t *testing.T) {
 	var tests = []struct {
 		desc    string
 		s       string
+		final   string
 		a       Action
 		invalid bool
 	}{
@@ -237,8 +238,13 @@ func Test_parseAction(t *testing.T) {
 			invalid: true,
 		},
 		{
-			s: "resubmit(1,)",
-			a: Resubmit(1, 0),
+			s: "resubmit:4",
+			a: Resubmit(4, 0),
+		},
+		{
+			s:     "resubmit(1,)",
+			final: "resubmit:1",
+			a:     Resubmit(1, 0),
 		},
 		{
 			s: "resubmit(,2)",
@@ -300,6 +306,10 @@ func Test_parseAction(t *testing.T) {
 			switch want {
 			case "LOCAL", "NORMAL":
 				want = strings.ToLower(want)
+			}
+
+			if tt.final != "" {
+				want = tt.final
 			}
 
 			if got := string(s); want != got {


### PR DESCRIPTION
Hit another parsing thing -- if we only specify port, OVS is going to give us: `resubmit:4` as the action.  This allows us to take both table/port resubmits (ex `resubmit(1,2)`) and port only resubmits.