### PR TITLE
ovs: Introduce separate action for ResubmitPort

### DIFF
--- a/ovs/action_test.go
+++ b/ovs/action_test.go
@@ -344,7 +344,7 @@ func TestActionResubmit(t *testing.T) {
 		{
 			desc:   "table zero",
 			port:   1,
-			action: "resubmit:1",
+			action: "resubmit(1,)",
 		},
 		{
 			desc:   "both port and table non-zero",
@@ -357,6 +357,60 @@ func TestActionResubmit(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
 			action, err := Resubmit(tt.port, tt.table).MarshalText()
+
+			if want, got := tt.err, err; want != got {
+				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+			if err != nil {
+				return
+			}
+
+			if want, got := tt.action, string(action); want != got {
+				t.Fatalf("unexpected Action:\n- want: %q\n-  got: %q",
+					want, got)
+			}
+		})
+	}
+}
+
+func TestActionResubmitPort(t *testing.T) {
+	var tests = []struct {
+		desc   string
+		port   int
+		action string
+		err    error
+	}{
+		{
+			desc: "invalid port",
+			port: -1,
+			err:  errResubmitPortInvalid,
+		},
+		{
+			desc:   "port zero",
+			port:   0,
+			action: "resubmit:0",
+		},
+		{
+			desc:   "port 1",
+			port:   1,
+			action: "resubmit:1",
+		},
+		{
+			desc:   "max port (0xfeff)",
+			port:   0xfeff,
+			action: "resubmit:65279",
+		},
+		{
+			desc: "max port+1 (0xfeff)",
+			port: 0xff00,
+			err:  errResubmitPortInvalid,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			action, err := ResubmitPort(tt.port).MarshalText()
 
 			if want, got := tt.err, err; want != got {
 				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v",

--- a/ovs/actionparser_test.go
+++ b/ovs/actionparser_test.go
@@ -239,12 +239,11 @@ func Test_parseAction(t *testing.T) {
 		},
 		{
 			s: "resubmit:4",
-			a: Resubmit(4, 0),
+			a: ResubmitPort(4),
 		},
 		{
-			s:     "resubmit(1,)",
-			final: "resubmit:1",
-			a:     Resubmit(1, 0),
+			s: "resubmit(1,)",
+			a: Resubmit(1, 0),
 		},
 		{
 			s: "resubmit(,2)",


### PR DESCRIPTION
Okay!

So, the problem here is that we are treating 0 as a special case for resubmit, when in fact 0 is a valid value for both tables and ports.  To start us off, this introduces ResubmitPort, to match and generate resubmits that look like `resubmit:123`.

We'll need to come back address resubmit to become ResubmitPortTable, but that's going to be a more involved change to make.

@mdlayher @keinohguchi 