### PR TITLE
ovs: update max openflow port past 1.0 standards

### DIFF
--- a/ovs/action.go
+++ b/ovs/action.go
@@ -404,8 +404,8 @@ type resubmitPortAction struct {
 
 // MarshalText implements Action.
 func (a *resubmitPortAction) MarshalText() ([]byte, error) {
-	// Largest valid port ID is 0xfeff per openflow spec.
-	if a.port < 0 || a.port > 0xfeff {
+	// Largest valid port ID is 0xfffffeff per openflow spec.
+	if a.port < 0 || a.port > 0xfffffeff {
 		return nil, errResubmitPortInvalid
 	}
 

--- a/ovs/action_test.go
+++ b/ovs/action_test.go
@@ -397,13 +397,13 @@ func TestActionResubmitPort(t *testing.T) {
 			action: "resubmit:1",
 		},
 		{
-			desc:   "max port (0xfeff)",
-			port:   0xfeff,
-			action: "resubmit:65279",
+			desc:   "max port (0xfffffeff)",
+			port:   0xfffffeff,
+			action: "resubmit:4294967039",
 		},
 		{
-			desc: "max port+1 (0xfeff)",
-			port: 0xff00,
+			desc: "max port+1 (0xfffffeff)",
+			port: 0xffffff00,
 			err:  errResubmitPortInvalid,
 		},
 	}


### PR DESCRIPTION
To enable us to use ports for Openflow 1.1+.  This lib needs to be made more version aware down the line.