### PR TITLE
ovs: do not attempt to parse NXST_FLOW in DumpFlows

### DIFF
--- a/ovs/openflow.go
+++ b/ovs/openflow.go
@@ -266,6 +266,11 @@ func (o *OpenFlowService) DumpFlows(bridge string) ([]*Flow, error) {
 
 	var flows []*Flow
 	err = parseEachLine(out, dumpFlowsPrefix, func(b []byte) error {
+		// Do not attempt to parse NXST_FLOW messages.
+		if bytes.HasPrefix(b, dumpFlowsPrefix) {
+			return nil
+		}
+
 		f := new(Flow)
 		if err := f.UnmarshalText(b); err != nil {
 			return err


### PR DESCRIPTION
We were attempting to parse this line, causing DumpFlows to mysteriously fail given a bridge with more that X flows configured.