### PR TITLE
ovs: add conj_id matcher

### DIFF
--- a/ovs/action_test.go
+++ b/ovs/action_test.go
@@ -531,6 +531,50 @@ func TestSetTunnel(t *testing.T) {
 	}
 }
 
+func TestConjunction(t *testing.T) {
+	var tests = []struct {
+		desc   string
+		a      Action
+		action string
+		err    error
+	}{
+		{
+			desc:   "set conjunction 1/2",
+			a:      Conjunction(123, 1, 2),
+			action: "conjunction(123, 1/2)",
+		},
+		{
+			desc:   "set conjunction 2/2",
+			a:      Conjunction(123, 2, 2),
+			action: "conjunction(123, 2/2)",
+		},
+		{
+			desc: "set conjunction 3/2",
+			a:    Conjunction(123, 3, 2),
+			err:  errDimensionTooLarge,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			action, err := tt.a.MarshalText()
+
+			if want, got := tt.err, err; want != got {
+				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+			if err != nil {
+				return
+			}
+
+			if want, got := tt.action, string(action); want != got {
+				t.Fatalf("unexpected Action:\n- want: %q\n-  got: %q",
+					want, got)
+			}
+		})
+	}
+}
+
 func TestActionGoString(t *testing.T) {
 	tests := []struct {
 		a Action
@@ -599,6 +643,10 @@ func TestActionGoString(t *testing.T) {
 		{
 			a: SetTunnel(10),
 			s: `ovs.SetTunnel(0xa)`,
+		},
+		{
+			a: Conjunction(123, 1, 2),
+			s: `ovs.Conjunction(123, 1, 2)`,
 		},
 	}
 

--- a/ovs/actionparser.go
+++ b/ovs/actionparser.go
@@ -297,6 +297,18 @@ func parseAction(s string) (Action, error) {
 		}
 	}
 
+	// ActionConjunction, with it's id, dimension number, and dimension size
+	if strings.HasPrefix(s, patConjunction[:len(patConjunction)-10]) {
+		var id, dimensionNumber, dimensionSize int
+		n, err := fmt.Sscanf(s, patConjunction, &id, &dimensionNumber, &dimensionSize)
+		if err != nil {
+			return nil, err
+		}
+		if n > 0 {
+			return Conjunction(id, dimensionNumber, dimensionSize), nil
+		}
+	}
+
 	// ActionOutput, with its port number
 	if strings.HasPrefix(s, patOutput[:len(patOutput)-2]) {
 		var port int

--- a/ovs/actionparser_test.go
+++ b/ovs/actionparser_test.go
@@ -281,6 +281,22 @@ func Test_parseAction(t *testing.T) {
 			s: "set_field:192.168.1.1->arp_spa",
 			a: SetField("192.168.1.1", "arp_spa"),
 		},
+		{
+			s: "conjunction(123, 1/2)",
+			a: Conjunction(123, 1, 2),
+		},
+		{
+			s: "conjunction(123, 2/2)",
+			a: Conjunction(123, 2, 2),
+		},
+		{
+			s:       "conjunction(123, 3/2)",
+			invalid: true,
+		},
+		{
+			s:       "conjunxxxxx(123, 3/2)",
+			invalid: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/ovs/match.go
+++ b/ovs/match.go
@@ -39,6 +39,7 @@ const (
 	arpSPA   = "arp_spa"
 	arpTHA   = "arp_tha"
 	arpTPA   = "arp_tpa"
+	conjID   = "conj_id"
 	ctMark   = "ct_mark"
 	ctState  = "ct_state"
 	ctZone   = "ct_zone"
@@ -245,6 +246,29 @@ func (m *networkMatch) GoString() string {
 	}
 
 	return fmt.Sprintf("ovs.NetworkDestination(%q)", m.ip)
+}
+
+// ConjunctionID matches flows that have matched all dimension of a conjunction
+// inside of the openflow table.
+func ConjunctionID(id uint32) Match {
+	return &conjunctionIDMatch{
+		id: id,
+	}
+}
+
+// A conjunctionIDMatch is a Match returned by ConjunctionID
+type conjunctionIDMatch struct {
+	id uint32
+}
+
+// MarshalText implements Match.
+func (m *conjunctionIDMatch) MarshalText() ([]byte, error) {
+	return bprintf("conj_id=%v", m.id), nil
+}
+
+// GoString implements Match.
+func (m *conjunctionIDMatch) GoString() string {
+	return fmt.Sprintf("ovs.ConjunctionID(%v)", m.id)
 }
 
 // NetworkProtocol matches packets with the specified IP or IPv6 protocol

--- a/ovs/match_test.go
+++ b/ovs/match_test.go
@@ -486,6 +486,39 @@ func TestMatchNetworkProtocol(t *testing.T) {
 	}
 }
 
+func TestMatchConjunctionID(t *testing.T) {
+	var tests = []struct {
+		desc string
+		num  uint32
+		out  string
+	}{
+		{
+			desc: "ID 1",
+			num:  1,
+			out:  "conj_id=1",
+		},
+		{
+			desc: "ID 11111",
+			num:  11111,
+			out:  "conj_id=11111",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			out, err := ConjunctionID(tt.num).MarshalText()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if want, got := tt.out, string(out); want != got {
+				t.Fatalf("unexpected Match output:\n- want: %q\n-  got: %q",
+					want, got)
+			}
+		})
+	}
+}
+
 func TestMatchConnectionTrackingState(t *testing.T) {
 	var tests = []struct {
 		desc string
@@ -997,6 +1030,10 @@ func TestMatchGoString(t *testing.T) {
 		{
 			m: TunnelIDWithMask(0xa, 0x0f),
 			s: `ovs.TunnelIDWithMask(0xa, 0xf)`,
+		},
+		{
+			m: ConjunctionID(123),
+			s: `ovs.ConjunctionID(123)`,
 		},
 	}
 

--- a/ovs/matchparser.go
+++ b/ovs/matchparser.go
@@ -33,6 +33,8 @@ func parseMatch(key string, value string) (Match, error) {
 		return parseIntMatch(key, value, math.MaxUint8)
 	case tpSRC, tpDST, ctZone:
 		return parseIntMatch(key, value, math.MaxUint16)
+	case conjID:
+		return parseIntMatch(key, value, math.MaxUint32)
 	case arpSPA:
 		return ARPSourceProtocolAddress(value), nil
 	case arpTPA:
@@ -108,6 +110,8 @@ func parseIntMatch(key string, value string, max int) (Match, error) {
 		return TransportDestinationPort(uint16(t)), nil
 	case ctZone:
 		return ConnectionTrackingZone(uint16(t)), nil
+	case conjID:
+		return ConjunctionID(uint32(t)), nil
 	}
 
 	return nil, fmt.Errorf("no action matched for %s=%s", key, value)

--- a/ovs/matchparser_test.go
+++ b/ovs/matchparser_test.go
@@ -287,6 +287,14 @@ func Test_parseMatch(t *testing.T) {
 			final: "tun_id=0xa/0x2",
 			m:     TunnelIDWithMask(10, 2),
 		},
+		{
+			s: "conj_id=123",
+			m: ConjunctionID(123),
+		},
+		{
+			s:       "conj_id=nope",
+			invalid: true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Allows us access to the conjunction matches and actions inside of OVS.  This allows us to discretely match on dimensions instead of needed a flow for each possible combination of dimensions.

See "Conjunction match fields" in:
http://www.openvswitch.org/support/dist-docs/ovs-fields.7.txt