### PR TITLE
go-openvswitch: add set-controller and SetSSLParam function

### DIFF
--- a/ovs/client.go
+++ b/ovs/client.go
@@ -308,6 +308,14 @@ func Protocols(versions []string) OptionFunc {
 	}
 }
 
+// SetSSLParam allows additional arbitary parameters to be appended in the end
+func SetSSLParam(pkey string, cert string, cacert string) OptionFunc {
+	return func(c *Client) {
+		c.ofctlFlags = append(c.ofctlFlags, fmt.Sprintf("--private-key=%s", pkey),
+			fmt.Sprintf("--certificate=%s", cert), fmt.Sprintf("--ca-cert=%s", cacert))
+	}
+}
+
 // Sudo specifies that "sudo" should be prefixed to all OVS commands.
 func Sudo() OptionFunc {
 	return func(c *Client) {

--- a/ovs/client_test.go
+++ b/ovs/client_test.go
@@ -29,24 +29,27 @@ func TestNew(t *testing.T) {
 		{
 			desc: "no options",
 			c: &Client{
-				flags: make([]string, 0),
-				debug: false,
+				flags:      make([]string, 0),
+				ofctlFlags: make([]string, 0),
+				debug:      false,
 			},
 		},
 		{
 			desc:    "Timeout(2)",
 			options: []OptionFunc{Timeout(2)},
 			c: &Client{
-				flags: []string{"--timeout=2"},
-				debug: false,
+				flags:      []string{"--timeout=2"},
+				ofctlFlags: make([]string, 0),
+				debug:      false,
 			},
 		},
 		{
 			desc:    "Debug(true)",
 			options: []OptionFunc{Debug(true)},
 			c: &Client{
-				flags: make([]string, 0),
-				debug: true,
+				flags:      make([]string, 0),
+				ofctlFlags: make([]string, 0),
+				debug:      true,
 			},
 		},
 		{
@@ -72,8 +75,9 @@ func TestNew(t *testing.T) {
 				Debug(true),
 			},
 			c: &Client{
-				flags: []string{"--timeout=5"},
-				debug: true,
+				flags:      []string{"--timeout=5"},
+				ofctlFlags: make([]string, 0),
+				debug:      true,
 			},
 		},
 		{
@@ -82,8 +86,19 @@ func TestNew(t *testing.T) {
 				Sudo(),
 			},
 			c: &Client{
-				flags: make([]string, 0),
-				sudo:  true,
+				flags:      make([]string, 0),
+				ofctlFlags: make([]string, 0),
+				sudo:       true,
+			},
+		},
+		{
+			desc: "SetSSLParam(pkey, cert, cacert)",
+			options: []OptionFunc{
+				SetSSLParam("privkey.pem", "cert.pem", "cacert.pem"),
+			},
+			c: &Client{
+				flags:      make([]string, 0),
+				ofctlFlags: []string{"--private-key=privkey.pem", "--certificate=cert.pem", "--ca-cert=cacert.pem"},
 			},
 		},
 	}
@@ -99,6 +114,15 @@ func TestNew(t *testing.T) {
 
 			if want, got := tt.c.debug, c.debug; !reflect.DeepEqual(want, got) {
 				t.Fatalf("unexpected Client.debug:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+			if want, got := tt.c.sudo, c.sudo; !reflect.DeepEqual(want, got) {
+				t.Fatalf("unexpected Client.sudo:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+
+			if want, got := tt.c.ofctlFlags, c.ofctlFlags; !reflect.DeepEqual(want, got) {
+				t.Fatalf("unexpected Client.ofctlFlags:\n- want: %v\n-  got: %v",
 					want, got)
 			}
 		})

--- a/ovs/vswitch.go
+++ b/ovs/vswitch.go
@@ -119,6 +119,13 @@ func (v *VSwitchService) SetFailMode(bridge string, mode FailMode) error {
 	return err
 }
 
+// SetController sets the controller for this bridge so that ovs-ofctl
+// can use this address to communicate.
+func (v *VSwitchService) SetController(bridge string, address string) error {
+	_, err := v.exec("set-controller", bridge, address)
+	return err
+}
+
 // exec executes an ExecFunc using 'ovs-vsctl'.
 func (v *VSwitchService) exec(args ...string) ([]byte, error) {
 	return v.c.exec("ovs-vsctl", args...)

--- a/ovs/vswitch_test.go
+++ b/ovs/vswitch_test.go
@@ -141,6 +141,32 @@ func TestClientVSwitchDeletePortOK(t *testing.T) {
 	}
 }
 
+func TestClientVSwitchSetControllerOK(t *testing.T) {
+	bridge := "br0"
+	address := "pssl:6653:127.0.0.1"
+
+	// Apply Timeout option to verify arguments
+	c := testClient([]OptionFunc{Timeout(1)}, func(cmd string, args ...string) ([]byte, error) {
+		// Verify correct command and arguments passed, including option flags
+		if want, got := "ovs-vsctl", cmd; want != got {
+			t.Fatalf("incorrect command:\n- want: %v\n-  got: %v",
+				want, got)
+		}
+
+		wantArgs := []string{"--timeout=1", "set-controller", string(bridge), address}
+		if want, got := wantArgs, args; !reflect.DeepEqual(want, got) {
+			t.Fatalf("incorrect arguments\n- want: %v\n-  got: %v",
+				want, got)
+		}
+
+		return nil, nil
+	})
+
+	if err := c.VSwitch.SetController(bridge, address); err != nil {
+		t.Fatalf("unexpected error for Client.VSwitch.SetController: %v", err)
+	}
+}
+
 func TestClientVSwitchListPorts(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
Add the ovs-ofctl set-controller command which is used to set the ovn controller
address. ovs-ofctl can use this address to communicate with ovs.
Also add SetSSLParam which is used to se the necessary SSL parameters like keys and certs. 
