### PR TITLE
Handle port range parsing for tp_dst and tp_src keys

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -12,3 +12,4 @@ Michael Ben-Ami <mbenami@digitalocean.com>
 Tejas Kokje <tkokje@digitalocean.com>
 Kei Nohguchi <knohguchi@digitalocean.com>
 Neal Shrader <nshrader@digitalocean.com>
+Sangeetha Srikanth <ssrikanth@digitalocean.com>

--- a/ovs/flow_test.go
+++ b/ovs/flow_test.go
@@ -278,6 +278,19 @@ func TestFlowMarshalText(t *testing.T) {
 			},
 			s: "priority=400,ip,nw_dst=192.0.2.1,table=45,idle_timeout=0,actions=conjunction(123,1/2)",
 		},
+		{
+			desc: "TP Port Range",
+			f: &Flow{
+				InPort: 72,
+				Matches: []Match{
+					TransportSourceMaskedPort(0xea60, 0xffe0),
+					TransportDestinationMaskedPort(60000, 0xffe0),
+				},
+				Table:   55,
+				Actions: []Action{Drop()},
+			},
+			s: "priority=0,in_port=72,tp_src=0xea60/0xffe0,tp_dst=0xea60/0xffe0,table=55,idle_timeout=0,actions=drop",
+		},
 	}
 
 	for _, tt := range tests {
@@ -735,6 +748,22 @@ func TestFlowUnmarshalText(t *testing.T) {
 				Actions: []Action{
 					Output(19),
 				},
+			},
+		},
+		{
+			desc: "TP Port Range",
+			s:    "priority=3000,tcp,in_port=72,tp_src=0xea60/0xffe0,tp_dst=0xea60/0xffe0,table=0,idle_timeout=0,actions=drop",
+			f: &Flow{
+				Priority: 3000,
+				Protocol: ProtocolTCPv4,
+				InPort:   72,
+				Matches: []Match{
+					TransportSourceMaskedPort(60000, 0xffe0),
+					TransportDestinationMaskedPort(0xea60, 0xffe0),
+				},
+				Table:       0,
+				IdleTimeout: 0,
+				Actions:     []Action{Drop()},
 			},
 		},
 	}

--- a/ovs/matchflow_test.go
+++ b/ovs/matchflow_test.go
@@ -203,6 +203,19 @@ func TestMatchFlowMarshalText(t *testing.T) {
 			},
 			s: "tcp,tcp_flags=+syn+ack,nw_dst=192.0.2.1,tp_dst=22,table=45",
 		},
+		{
+			desc: "TP port range flow",
+			f: &MatchFlow{
+				Protocol: ProtocolUDPv4,
+				InPort:   33,
+				Matches: []Match{
+					NetworkDestination("192.0.2.1"),
+					TransportDestinationMaskedPort(0xea60, 0xffe0),
+				},
+				Table: 55,
+			},
+			s: "udp,in_port=33,nw_dst=192.0.2.1,tp_dst=0xea60/0xffe0,table=55",
+		},
 	}
 
 	for _, tt := range tests {

--- a/ovs/matchparser_test.go
+++ b/ovs/matchparser_test.go
@@ -295,6 +295,46 @@ func Test_parseMatch(t *testing.T) {
 			s:       "conj_id=nope",
 			invalid: true,
 		},
+		{
+			desc:    "tp_dst out of range 65536/0xffe0",
+			s:       "tp_dst=65536/0xffe0",
+			invalid: true,
+		},
+		{
+			desc:    "tp_dst out of range 0x10000/0xffe0",
+			s:       "tp_dst=0x10000/0xffe0",
+			invalid: true,
+		},
+		{
+			desc:    "tp_dst out of range 0xea60/0x10000",
+			s:       "tp_dst=0xea60/0x10000",
+			invalid: true,
+		},
+		{
+			desc: "tp_dst 0xea60/0xffe0",
+			s:    "tp_dst=0xea60/0xffe0",
+			m:    TransportDestinationMaskedPort(0xea60, 0xffe0),
+		},
+		{
+			desc:    "tp_src out of range 65536/0xffe0",
+			s:       "tp_src=65536/0xffe0",
+			invalid: true,
+		},
+		{
+			desc:    "tp_src out of range 0x10000/0xffe0",
+			s:       "tp_src=0x10000/0xffe0",
+			invalid: true,
+		},
+		{
+			desc:    "tp_src out of range 0xea60/0x10000",
+			s:       "tp_src=0xea60/0x10000",
+			invalid: true,
+		},
+		{
+			desc: "tp_src 0xea60/0xffe0",
+			s:    "tp_src=0xea60/0xffe0",
+			m:    TransportSourceMaskedPort(0xea60, 0xffe0),
+		},
 	}
 
 	for _, tt := range tests {

--- a/ovs/matchparser_test.go
+++ b/ovs/matchparser_test.go
@@ -316,6 +316,11 @@ func Test_parseMatch(t *testing.T) {
 			m:    TransportDestinationMaskedPort(0xea60, 0xffe0),
 		},
 		{
+			desc:    "tp_dst 0xea60/0xffe0/0xdddd",
+			s:       "tp_dst=0xea60/0xffe0/0xdddd",
+			invalid: true,
+		},
+		{
 			desc:    "tp_src out of range 65536/0xffe0",
 			s:       "tp_src=65536/0xffe0",
 			invalid: true,
@@ -334,6 +339,11 @@ func Test_parseMatch(t *testing.T) {
 			desc: "tp_src 0xea60/0xffe0",
 			s:    "tp_src=0xea60/0xffe0",
 			m:    TransportSourceMaskedPort(0xea60, 0xffe0),
+		},
+		{
+			desc:    "tp_src 0xea60/0xffe0/0xdddd",
+			s:       "tp_src=0xea60/0xffe0/0xdddd",
+			invalid: true,
 		},
 	}
 


### PR DESCRIPTION
Parsing of a flow with tp_dst and tp_src in port/mask format does not work.
Currently parseIntMatch() assumes only a single port in tp_dst and tp_src and not a port-range. As a result parsing a flow with port range fails.
This fix adds logic to parse tp_dst and tp_src in port-range format in a flow.

tp_dst=0xea60/0xffe0