### PR TITLE
add get-controller which is used to get the current controller address

### DIFF
--- a/ovs/vswitch.go
+++ b/ovs/vswitch.go
@@ -126,6 +126,15 @@ func (v *VSwitchService) SetController(bridge string, address string) error {
 	return err
 }
 
+// GetController gets the controller address for this bridge.
+func (v *VSwitchService) GetController(bridge string) (string, error) {
+	address, err := v.exec("get-controller", bridge)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(address)), err
+}
+
 // exec executes an ExecFunc using 'ovs-vsctl'.
 func (v *VSwitchService) exec(args ...string) ([]byte, error) {
 	return v.c.exec("ovs-vsctl", args...)

--- a/ovs/vswitch_test.go
+++ b/ovs/vswitch_test.go
@@ -167,6 +167,36 @@ func TestClientVSwitchSetControllerOK(t *testing.T) {
 	}
 }
 
+func TestClientVSwitchGetControllerOK(t *testing.T) {
+	bridge := "br0"
+	address := "pssl:6653:127.0.0.1"
+
+	// Apply Timeout option to verify arguments
+	c := testClient([]OptionFunc{Timeout(1)}, func(cmd string, args ...string) ([]byte, error) {
+		// Verify correct command and arguments passed, including option flags
+		if want, got := "ovs-vsctl", cmd; want != got {
+			t.Fatalf("incorrect command:\n- want: %v\n-  got: %v",
+				want, got)
+		}
+
+		wantArgs := []string{"--timeout=1", "get-controller", string(bridge)}
+		if want, got := wantArgs, args; !reflect.DeepEqual(want, got) {
+			t.Fatalf("incorrect arguments\n- want: %v\n-  got: %v",
+				want, got)
+		}
+
+		return []byte(address), nil
+	})
+
+	gotAddress, err := c.VSwitch.GetController(bridge)
+	if err != nil {
+		t.Fatalf("unexpected error for Client.VSwitch.GetController: %v", err)
+	}
+	if gotAddress != address {
+		t.Fatalf("Controller address missmatch\n- got: %v\n- want: %v", gotAddress, address)
+	}
+}
+
 func TestClientVSwitchListPorts(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
Applications use this to get the current controller address set in ovs.
this is needed if user wants to verify if the ovs has the address currently
support, if not user can overwrite it with the supported one.
Also add the unit test.