### PR TITLE
ovsnl/internal/ovsh: regenerate constants and types

### DIFF
--- a/ovsnl/internal/ovsh/const.go
+++ b/ovsnl/internal/ovsh/const.go
@@ -12,102 +12,116 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// WARNING: This file has automatically been generated on Wed, 01 Nov 2017 17:18:09 EDT.
+// WARNING: This file has automatically been generated on Tue, 08 May 2018 08:48:40 EDT.
 // By https://git.io/c-for-go. DO NOT EDIT.
 
 package ovsh
 
 const (
-	// DatapathFamily as defined in ovsh/openvswitch.h:41
+	// DatapathFamily as defined in ovsh/openvswitch.h:42
 	DatapathFamily = "ovs_datapath"
-	// DatapathMcgroup as defined in ovsh/openvswitch.h:42
+	// DatapathMcgroup as defined in ovsh/openvswitch.h:43
 	DatapathMcgroup = "ovs_datapath"
-	// DatapathVersion as defined in ovsh/openvswitch.h:48
+	// DatapathVersion as defined in ovsh/openvswitch.h:49
 	DatapathVersion = 2
-	// DpVerFeatures as defined in ovsh/openvswitch.h:51
+	// DpVerFeatures as defined in ovsh/openvswitch.h:52
 	DpVerFeatures = 2
-	// DpAttrMax as defined in ovsh/openvswitch.h:91
+	// DpAttrMax as defined in ovsh/openvswitch.h:92
 	DpAttrMax = (__DpAttrMax - 1)
-	// DpFUnaligned as defined in ovsh/openvswitch.h:120
+	// DpFUnaligned as defined in ovsh/openvswitch.h:121
 	DpFUnaligned = (1 << 0)
-	// DpFVportPids as defined in ovsh/openvswitch.h:123
+	// DpFVportPids as defined in ovsh/openvswitch.h:124
 	DpFVportPids = (1 << 1)
-	// PacketFamily as defined in ovsh/openvswitch.h:130
+	// PacketFamily as defined in ovsh/openvswitch.h:131
 	PacketFamily = "ovs_packet"
-	// PacketVersion as defined in ovsh/openvswitch.h:131
+	// PacketVersion as defined in ovsh/openvswitch.h:132
 	PacketVersion = 0x1
-	// PacketAttrMax as defined in ovsh/openvswitch.h:193
+	// PacketAttrMax as defined in ovsh/openvswitch.h:194
 	PacketAttrMax = (__PacketAttrMax - 1)
-	// VportFamily as defined in ovsh/openvswitch.h:197
+	// VportFamily as defined in ovsh/openvswitch.h:198
 	VportFamily = "ovs_vport"
-	// VportMcgroup as defined in ovsh/openvswitch.h:198
+	// VportMcgroup as defined in ovsh/openvswitch.h:199
 	VportMcgroup = "ovs_vport"
-	// VportVersion as defined in ovsh/openvswitch.h:199
+	// VportVersion as defined in ovsh/openvswitch.h:200
 	VportVersion = 0x1
-	// VportTypeMax as defined in ovsh/openvswitch.h:219
+	// VportTypeMax as defined in ovsh/openvswitch.h:220
 	VportTypeMax = (__VportTypeMax - 1)
-	// VportAttrMax as defined in ovsh/openvswitch.h:263
+	// VportAttrMax as defined in ovsh/openvswitch.h:266
 	VportAttrMax = (__VportAttrMax - 1)
-	// VxlanExtMax as defined in ovsh/openvswitch.h:271
+	// VxlanExtMax as defined in ovsh/openvswitch.h:274
 	VxlanExtMax = (__VxlanExtMax - 1)
-	// TunnelAttrMax as defined in ovsh/openvswitch.h:283
+	// TunnelAttrMax as defined in ovsh/openvswitch.h:286
 	TunnelAttrMax = (__TunnelAttrMax - 1)
-	// FlowFamily as defined in ovsh/openvswitch.h:287
+	// FlowFamily as defined in ovsh/openvswitch.h:290
 	FlowFamily = "ovs_flow"
-	// FlowMcgroup as defined in ovsh/openvswitch.h:288
+	// FlowMcgroup as defined in ovsh/openvswitch.h:291
 	FlowMcgroup = "ovs_flow"
-	// FlowVersion as defined in ovsh/openvswitch.h:289
+	// FlowVersion as defined in ovsh/openvswitch.h:292
 	FlowVersion = 0x1
-	// KeyAttrMax as defined in ovsh/openvswitch.h:343
+	// KeyAttrMax as defined in ovsh/openvswitch.h:347
 	KeyAttrMax = (__KeyAttrMax - 1)
-	// TunnelKeyAttrMax as defined in ovsh/openvswitch.h:365
+	// TunnelKeyAttrMax as defined in ovsh/openvswitch.h:370
 	TunnelKeyAttrMax = (__TunnelKeyAttrMax - 1)
-	// FragTypeMax as defined in ovsh/openvswitch.h:383
+	// FragTypeMax as defined in ovsh/openvswitch.h:388
 	FragTypeMax = (__FragTypeMax - 1)
-	// CtLabelsLen32 as defined in ovsh/openvswitch.h:452
+	// CtLabelsLen32 as defined in ovsh/openvswitch.h:457
 	CtLabelsLen32 = 4
-	// CsFNew as defined in ovsh/openvswitch.h:462
+	// CsFNew as defined in ovsh/openvswitch.h:467
 	CsFNew = 0x01
-	// CsFEstablished as defined in ovsh/openvswitch.h:463
+	// CsFEstablished as defined in ovsh/openvswitch.h:468
 	CsFEstablished = 0x02
-	// CsFRelated as defined in ovsh/openvswitch.h:464
+	// CsFRelated as defined in ovsh/openvswitch.h:469
 	CsFRelated = 0x04
-	// CsFReplyDir as defined in ovsh/openvswitch.h:466
+	// CsFReplyDir as defined in ovsh/openvswitch.h:471
 	CsFReplyDir = 0x08
-	// CsFInvalid as defined in ovsh/openvswitch.h:467
+	// CsFInvalid as defined in ovsh/openvswitch.h:472
 	CsFInvalid = 0x10
-	// CsFTracked as defined in ovsh/openvswitch.h:468
+	// CsFTracked as defined in ovsh/openvswitch.h:473
 	CsFTracked = 0x20
-	// CsFSrcNat as defined in ovsh/openvswitch.h:469
+	// CsFSrcNat as defined in ovsh/openvswitch.h:474
 	CsFSrcNat = 0x40
-	// CsFDstNat as defined in ovsh/openvswitch.h:472
+	// CsFDstNat as defined in ovsh/openvswitch.h:477
 	CsFDstNat = 0x80
-	// CsFNatMask as defined in ovsh/openvswitch.h:476
+	// CsFNatMask as defined in ovsh/openvswitch.h:481
 	CsFNatMask = (CsFSrcNat | CsFDstNat)
-	// FlowAttrMax as defined in ovsh/openvswitch.h:553
+	// NshKeyAttrMax as defined in ovsh/openvswitch.h:507
+	NshKeyAttrMax = (__NshKeyAttrMax - 1)
+	// FlowAttrMax as defined in ovsh/openvswitch.h:582
 	FlowAttrMax = (__FlowAttrMax - 1)
-	// UfidFOmitKey as defined in ovsh/openvswitch.h:561
+	// UfidFOmitKey as defined in ovsh/openvswitch.h:590
 	UfidFOmitKey = (1 << 0)
-	// UfidFOmitMask as defined in ovsh/openvswitch.h:562
+	// UfidFOmitMask as defined in ovsh/openvswitch.h:591
 	UfidFOmitMask = (1 << 1)
-	// UfidFOmitActions as defined in ovsh/openvswitch.h:563
+	// UfidFOmitActions as defined in ovsh/openvswitch.h:592
 	UfidFOmitActions = (1 << 2)
-	// SampleAttrMax as defined in ovsh/openvswitch.h:588
+	// SampleAttrMax as defined in ovsh/openvswitch.h:617
 	SampleAttrMax = (__SampleAttrMax - 1)
-	// UserspaceAttrMax as defined in ovsh/openvswitch.h:621
+	// UserspaceAttrMax as defined in ovsh/openvswitch.h:650
 	UserspaceAttrMax = (__UserspaceAttrMax - 1)
-	// CtAttrMax as defined in ovsh/openvswitch.h:723
+	// CtAttrMax as defined in ovsh/openvswitch.h:752
 	CtAttrMax = (__CtAttrMax - 1)
-	// NatAttrMax as defined in ovsh/openvswitch.h:761
+	// NatAttrMax as defined in ovsh/openvswitch.h:790
 	NatAttrMax = (__NatAttrMax - 1)
-	// ActionAttrMax as defined in ovsh/openvswitch.h:849
+	// ActionAttrMax as defined in ovsh/openvswitch.h:887
 	ActionAttrMax = (__ActionAttrMax - 1)
+	// MeterFamily as defined in ovsh/openvswitch.h:890
+	MeterFamily = "ovs_meter"
+	// MeterMcgroup as defined in ovsh/openvswitch.h:891
+	MeterMcgroup = "ovs_meter"
+	// MeterVersion as defined in ovsh/openvswitch.h:892
+	MeterVersion = 0x1
+	// MeterAttrMax as defined in ovsh/openvswitch.h:919
+	MeterAttrMax = (__MeterAttrMax - 1)
+	// BandAttrMax as defined in ovsh/openvswitch.h:930
+	BandAttrMax = (__BandAttrMax - 1)
+	// MeterBandTypeMax as defined in ovsh/openvswitch.h:938
+	MeterBandTypeMax = (__MeterBandTypeMax - 1)
 )
 
-// ovsDatapathCmd as declared in ovsh/openvswitch.h:53
+// ovsDatapathCmd as declared in ovsh/openvswitch.h:54
 type ovsDatapathCmd int32
 
-// ovsDatapathCmd enumeration from ovsh/openvswitch.h:53
+// ovsDatapathCmd enumeration from ovsh/openvswitch.h:54
 const (
 	DpCmdUnspec = iota
 	DpCmdNew    = 1
@@ -116,10 +130,10 @@ const (
 	DpCmdSet    = 4
 )
 
-// ovsDatapathAttr as declared in ovsh/openvswitch.h:80
+// ovsDatapathAttr as declared in ovsh/openvswitch.h:81
 type ovsDatapathAttr int32
 
-// ovsDatapathAttr enumeration from ovsh/openvswitch.h:80
+// ovsDatapathAttr enumeration from ovsh/openvswitch.h:81
 const (
 	DpAttrUnspec        = iota
 	DpAttrName          = 1
@@ -131,10 +145,10 @@ const (
 	__DpAttrMax         = 7
 )
 
-// ovsPacketCmd as declared in ovsh/openvswitch.h:133
+// ovsPacketCmd as declared in ovsh/openvswitch.h:134
 type ovsPacketCmd int32
 
-// ovsPacketCmd enumeration from ovsh/openvswitch.h:133
+// ovsPacketCmd enumeration from ovsh/openvswitch.h:134
 const (
 	PacketCmdUnspec  = iota
 	PacketCmdMiss    = 1
@@ -142,10 +156,10 @@ const (
 	PacketCmdExecute = 3
 )
 
-// ovsPacketAttr as declared in ovsh/openvswitch.h:176
+// ovsPacketAttr as declared in ovsh/openvswitch.h:177
 type ovsPacketAttr int32
 
-// ovsPacketAttr enumeration from ovsh/openvswitch.h:176
+// ovsPacketAttr enumeration from ovsh/openvswitch.h:177
 const (
 	PacketAttrUnspec       = iota
 	PacketAttrPacket       = 1
@@ -161,10 +175,10 @@ const (
 	__PacketAttrMax        = 11
 )
 
-// ovsVportCmd as declared in ovsh/openvswitch.h:201
+// ovsVportCmd as declared in ovsh/openvswitch.h:202
 type ovsVportCmd int32
 
-// ovsVportCmd enumeration from ovsh/openvswitch.h:201
+// ovsVportCmd enumeration from ovsh/openvswitch.h:202
 const (
 	VportCmdUnspec = iota
 	VportCmdNew    = 1
@@ -173,10 +187,10 @@ const (
 	VportCmdSet    = 4
 )
 
-// ovsVportType as declared in ovsh/openvswitch.h:209
+// ovsVportType as declared in ovsh/openvswitch.h:210
 type ovsVportType int32
 
-// ovsVportType enumeration from ovsh/openvswitch.h:209
+// ovsVportType enumeration from ovsh/openvswitch.h:210
 const (
 	VportTypeUnspec   = iota
 	VportTypeNetdev   = 1
@@ -187,10 +201,10 @@ const (
 	__VportTypeMax    = 6
 )
 
-// ovsVportAttr as declared in ovsh/openvswitch.h:250
+// ovsVportAttr as declared in ovsh/openvswitch.h:251
 type ovsVportAttr int32
 
-// ovsVportAttr enumeration from ovsh/openvswitch.h:250
+// ovsVportAttr enumeration from ovsh/openvswitch.h:251
 const (
 	VportAttrUnspec    = iota
 	VportAttrPortNo    = 1
@@ -200,33 +214,35 @@ const (
 	VportAttrUpcallPid = 5
 	VportAttrStats     = 6
 	VportAttrPad       = 7
-	__VportAttrMax     = 8
+	VportAttrIfindex   = 8
+	VportAttrNetnsid   = 9
+	__VportAttrMax     = 10
 )
 
 const (
-	// VxlanExtUnspec as declared in ovsh/openvswitch.h:266
+	// VxlanExtUnspec as declared in ovsh/openvswitch.h:269
 	VxlanExtUnspec = iota
-	// VxlanExtGbp as declared in ovsh/openvswitch.h:267
+	// VxlanExtGbp as declared in ovsh/openvswitch.h:270
 	VxlanExtGbp = 1
-	// __VxlanExtMax as declared in ovsh/openvswitch.h:268
+	// __VxlanExtMax as declared in ovsh/openvswitch.h:271
 	__VxlanExtMax = 2
 )
 
 const (
-	// TunnelAttrUnspec as declared in ovsh/openvswitch.h:277
+	// TunnelAttrUnspec as declared in ovsh/openvswitch.h:280
 	TunnelAttrUnspec = iota
-	// TunnelAttrDstPort as declared in ovsh/openvswitch.h:278
+	// TunnelAttrDstPort as declared in ovsh/openvswitch.h:281
 	TunnelAttrDstPort = 1
-	// TunnelAttrExtension as declared in ovsh/openvswitch.h:279
+	// TunnelAttrExtension as declared in ovsh/openvswitch.h:282
 	TunnelAttrExtension = 2
-	// __TunnelAttrMax as declared in ovsh/openvswitch.h:280
+	// __TunnelAttrMax as declared in ovsh/openvswitch.h:283
 	__TunnelAttrMax = 3
 )
 
-// ovsFlowCmd as declared in ovsh/openvswitch.h:291
+// ovsFlowCmd as declared in ovsh/openvswitch.h:294
 type ovsFlowCmd int32
 
-// ovsFlowCmd enumeration from ovsh/openvswitch.h:291
+// ovsFlowCmd enumeration from ovsh/openvswitch.h:294
 const (
 	FlowCmdUnspec = iota
 	FlowCmdNew    = 1
@@ -235,10 +251,10 @@ const (
 	FlowCmdSet    = 4
 )
 
-// ovsKeyAttr as declared in ovsh/openvswitch.h:304
+// ovsKeyAttr as declared in ovsh/openvswitch.h:307
 type ovsKeyAttr int32
 
-// ovsKeyAttr enumeration from ovsh/openvswitch.h:304
+// ovsKeyAttr enumeration from ovsh/openvswitch.h:307
 const (
 	KeyAttrUnspec          = iota
 	KeyAttrEncap           = 1
@@ -268,13 +284,14 @@ const (
 	KeyAttrCtLabels        = 25
 	KeyAttrCtOrigTupleIpv4 = 26
 	KeyAttrCtOrigTupleIpv6 = 27
-	__KeyAttrMax           = 28
+	KeyAttrNsh             = 28
+	__KeyAttrMax           = 29
 )
 
-// ovsTunnelKeyAttr as declared in ovsh/openvswitch.h:345
+// ovsTunnelKeyAttr as declared in ovsh/openvswitch.h:349
 type ovsTunnelKeyAttr int32
 
-// ovsTunnelKeyAttr enumeration from ovsh/openvswitch.h:345
+// ovsTunnelKeyAttr enumeration from ovsh/openvswitch.h:349
 const (
 	TunnelKeyAttrId           = iota
 	TunnelKeyAttrIpv4Src      = 1
@@ -291,13 +308,14 @@ const (
 	TunnelKeyAttrIpv6Src      = 12
 	TunnelKeyAttrIpv6Dst      = 13
 	TunnelKeyAttrPad          = 14
-	__TunnelKeyAttrMax        = 15
+	TunnelKeyAttrErspanOpts   = 15
+	__TunnelKeyAttrMax        = 16
 )
 
-// ovsFragType as declared in ovsh/openvswitch.h:376
+// ovsFragType as declared in ovsh/openvswitch.h:381
 type ovsFragType int32
 
-// ovsFragType enumeration from ovsh/openvswitch.h:376
+// ovsFragType enumeration from ovsh/openvswitch.h:381
 const (
 	FragTypeNone  = iota
 	FragTypeFirst = 1
@@ -305,10 +323,22 @@ const (
 	__FragTypeMax = 3
 )
 
-// ovsFlowAttr as declared in ovsh/openvswitch.h:536
+// ovsNshKeyAttr as declared in ovsh/openvswitch.h:499
+type ovsNshKeyAttr int32
+
+// ovsNshKeyAttr enumeration from ovsh/openvswitch.h:499
+const (
+	NshKeyAttrUnspec = iota
+	NshKeyAttrBase   = 1
+	NshKeyAttrMd1    = 2
+	NshKeyAttrMd2    = 3
+	__NshKeyAttrMax  = 4
+)
+
+// ovsFlowAttr as declared in ovsh/openvswitch.h:565
 type ovsFlowAttr int32
 
-// ovsFlowAttr enumeration from ovsh/openvswitch.h:536
+// ovsFlowAttr enumeration from ovsh/openvswitch.h:565
 const (
 	FlowAttrUnspec    = iota
 	FlowAttrKey       = 1
@@ -325,10 +355,10 @@ const (
 	__FlowAttrMax     = 12
 )
 
-// ovsSampleAttr as declared in ovsh/openvswitch.h:577
+// ovsSampleAttr as declared in ovsh/openvswitch.h:606
 type ovsSampleAttr int32
 
-// ovsSampleAttr enumeration from ovsh/openvswitch.h:577
+// ovsSampleAttr enumeration from ovsh/openvswitch.h:606
 const (
 	SampleAttrUnspec      = iota
 	SampleAttrProbability = 1
@@ -336,10 +366,10 @@ const (
 	__SampleAttrMax       = 3
 )
 
-// ovsUserspaceAttr as declared in ovsh/openvswitch.h:611
+// ovsUserspaceAttr as declared in ovsh/openvswitch.h:640
 type ovsUserspaceAttr int32
 
-// ovsUserspaceAttr enumeration from ovsh/openvswitch.h:611
+// ovsUserspaceAttr enumeration from ovsh/openvswitch.h:640
 const (
 	UserspaceAttrUnspec        = iota
 	UserspaceAttrPid           = 1
@@ -349,18 +379,18 @@ const (
 	__UserspaceAttrMax         = 5
 )
 
-// ovsHashAlg as declared in ovsh/openvswitch.h:663
+// ovsHashAlg as declared in ovsh/openvswitch.h:692
 type ovsHashAlg int32
 
-// ovsHashAlg enumeration from ovsh/openvswitch.h:663
+// ovsHashAlg enumeration from ovsh/openvswitch.h:692
 const (
 	HashAlgL4 = iota
 )
 
-// ovsCtAttr as declared in ovsh/openvswitch.h:709
+// ovsCtAttr as declared in ovsh/openvswitch.h:738
 type ovsCtAttr int32
 
-// ovsCtAttr enumeration from ovsh/openvswitch.h:709
+// ovsCtAttr enumeration from ovsh/openvswitch.h:738
 const (
 	CtAttrUnspec      = iota
 	CtAttrCommit      = 1
@@ -374,10 +404,10 @@ const (
 	__CtAttrMax       = 9
 )
 
-// ovsNatAttr as declared in ovsh/openvswitch.h:747
+// ovsNatAttr as declared in ovsh/openvswitch.h:776
 type ovsNatAttr int32
 
-// ovsNatAttr enumeration from ovsh/openvswitch.h:747
+// ovsNatAttr enumeration from ovsh/openvswitch.h:776
 const (
 	NatAttrUnspec      = iota
 	NatAttrSrc         = 1
@@ -392,10 +422,10 @@ const (
 	__NatAttrMax       = 10
 )
 
-// ovsActionAttr as declared in ovsh/openvswitch.h:818
+// ovsActionAttr as declared in ovsh/openvswitch.h:852
 type ovsActionAttr int32
 
-// ovsActionAttr enumeration from ovsh/openvswitch.h:818
+// ovsActionAttr enumeration from ovsh/openvswitch.h:852
 const (
 	ActionAttrUnspec    = iota
 	ActionAttrOutput    = 1
@@ -413,5 +443,62 @@ const (
 	ActionAttrTrunc     = 13
 	ActionAttrPushEth   = 14
 	ActionAttrPopEth    = 15
-	__ActionAttrMax     = 16
+	ActionAttrCtClear   = 16
+	ActionAttrPushNsh   = 17
+	ActionAttrPopNsh    = 18
+	ActionAttrMeter     = 19
+	__ActionAttrMax     = 20
+)
+
+// ovsMeterCmd as declared in ovsh/openvswitch.h:894
+type ovsMeterCmd int32
+
+// ovsMeterCmd enumeration from ovsh/openvswitch.h:894
+const (
+	MeterCmdUnspec   = iota
+	MeterCmdFeatures = 1
+	MeterCmdSet      = 2
+	MeterCmdDel      = 3
+	MeterCmdGet      = 4
+)
+
+// ovsMeterAttr as declared in ovsh/openvswitch.h:902
+type ovsMeterAttr int32
+
+// ovsMeterAttr enumeration from ovsh/openvswitch.h:902
+const (
+	MeterAttrUnspec    = iota
+	MeterAttrId        = 1
+	MeterAttrKbps      = 2
+	MeterAttrStats     = 3
+	MeterAttrBands     = 4
+	MeterAttrUsed      = 5
+	MeterAttrClear     = 6
+	MeterAttrMaxMeters = 7
+	MeterAttrMaxBands  = 8
+	MeterAttrPad       = 9
+	__MeterAttrMax     = 10
+)
+
+// ovsBandAttr as declared in ovsh/openvswitch.h:921
+type ovsBandAttr int32
+
+// ovsBandAttr enumeration from ovsh/openvswitch.h:921
+const (
+	BandAttrUnspec = iota
+	BandAttrType   = 1
+	BandAttrRate   = 2
+	BandAttrBurst  = 3
+	BandAttrStats  = 4
+	__BandAttrMax  = 5
+)
+
+// ovsMeterBandType as declared in ovsh/openvswitch.h:932
+type ovsMeterBandType int32
+
+// ovsMeterBandType enumeration from ovsh/openvswitch.h:932
+const (
+	MeterBandTypeUnspec = iota
+	MeterBandTypeDrop   = 1
+	__MeterBandTypeMax  = 2
 )


### PR DESCRIPTION
We aren't using any of this but it can't hurt to bring it up to date.