### PR TITLE
Support the TCP connection for OVSDB

### DIFF
--- a/ovs/client.go
+++ b/ovs/client.go
@@ -318,10 +318,10 @@ func SetSSLParam(pkey string, cert string, cacert string) OptionFunc {
 }
 
 // SetTCPParam configures the OVSDB connection using a TCP format ip:port
-// for use with all ovs commands
-func SetTCPParam(ip string, port string) OptionFunc {
+// for use with all ovs-vsctl commands.
+func SetTCPParam(addr string) OptionFunc {
 	return func(c *Client) {
-		c.flags= append(c.ofctlFlags, fmt.Sprintf("--db=tcp:%s:%s", ip, port))
+		c.flags= append(c.flags, fmt.Sprintf("--db=tcp:%s", addr))
 	}
 }
 

--- a/ovs/client.go
+++ b/ovs/client.go
@@ -317,6 +317,14 @@ func SetSSLParam(pkey string, cert string, cacert string) OptionFunc {
 	}
 }
 
+// SetTCPParam configures the OVSDB connection using a TCP format ip:port
+// for use with all ovs commands
+func SetTCPParam(ip string, port string) OptionFunc {
+	return func(c *Client) {
+		c.flags= append(c.ofctlFlags, fmt.Sprintf("--db=tcp:%s:%s", ip, port))
+	}
+}
+
 // Sudo specifies that "sudo" should be prefixed to all OVS commands.
 func Sudo() OptionFunc {
 	return func(c *Client) {

--- a/ovs/client_test.go
+++ b/ovs/client_test.go
@@ -102,9 +102,9 @@ func TestNew(t *testing.T) {
 			},
 		},
 		{
-			desc: "SetTCPParam(ip, port)",
+			desc: "SetTCPParam(addr)",
 			options: []OptionFunc{
-				SetTCPParam("127.0.0.1", "6640"),
+				SetTCPParam("127.0.0.1:6640"),
 			},
 			c: &Client{
 				flags: []string{"--db=tcp:127.0.0.1:6640"},

--- a/ovs/client_test.go
+++ b/ovs/client_test.go
@@ -101,6 +101,17 @@ func TestNew(t *testing.T) {
 				ofctlFlags: []string{"--private-key=privkey.pem", "--certificate=cert.pem", "--ca-cert=cacert.pem"},
 			},
 		},
+		{
+			desc: "SetTCPParam(ip, port)",
+			options: []OptionFunc{
+				SetTCPParam("127.0.0.1", "6640"),
+			},
+			c: &Client{
+				flags: []string{"--db=tcp:127.0.0.1:6640"},
+				ofctlFlags: make([]string, 0),
+			},
+		},
+
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Support the TCP connection method for OVSDB and it should be applied to all ovs commands.