### PR TITLE
Check if list bridge output is empty

### DIFF
--- a/ovs/vswitch.go
+++ b/ovs/vswitch.go
@@ -77,6 +77,9 @@ func (v *VSwitchService) ListPorts(bridge string) ([]string, error) {
 		return nil, err
 	}
 
+	if string(output) == "" {
+		return nil, nil
+	}
 	ports := strings.Split(strings.TrimSpace(string(output)), "\n")
 	return ports, err
 }

--- a/ovs/vswitch.go
+++ b/ovs/vswitch.go
@@ -88,6 +88,9 @@ func (v *VSwitchService) ListBridges() ([]string, error) {
 		return nil, err
 	}
 
+	if string(output) == "" {
+		return nil, nil
+	}
 	bridges := strings.Split(strings.TrimSpace(string(output)), "\n")
 	return bridges, err
 }

--- a/ovs/vswitch_test.go
+++ b/ovs/vswitch_test.go
@@ -206,6 +206,15 @@ func TestClientVSwitchListPorts(t *testing.T) {
 		c     *Client
 	}{
 		{
+			name:  "test br0 bonded with no interface",
+			input: "br0",
+			want:  nil,
+			err:   nil,
+			c: testClient(nil, func(cmd string, args ...string) ([]byte, error) {
+				return []byte(""), nil
+			}),
+		},
+		{
 			name:  "test br0 bonded",
 			input: "br0",
 			want:  []string{"bond0"},

--- a/ovs/vswitch_test.go
+++ b/ovs/vswitch_test.go
@@ -261,6 +261,14 @@ func TestClientVSwitchListBridges(t *testing.T) {
 		c    *Client
 	}{
 		{
+			name: "test no bridge",
+			want: nil,
+			err:  nil,
+			c: testClient(nil, func(cmd string, args ...string) ([]byte, error) {
+				return []byte(""), nil
+			}),
+		},
+		{
 			name: "test single bridge",
 			want: []string{"br0"},
 			err:  nil,


### PR DESCRIPTION
Looks like `strings.Split` will let VSwitch.ListBridges()  result to []string{""} not []string{} 
if `ovs-vsctl list-br` output string is empty: "".