### PR TITLE
Added ICMPv6 code and type to OVS match

### DIFF
--- a/ovs/match.go
+++ b/ovs/match.go
@@ -50,6 +50,9 @@ const (
 	dlVLAN    = "dl_vlan"
 	dlVLANPCP = "dl_vlan_pcp"
 	icmpType  = "icmp_type"
+	icmpCode  = "icmp_code"
+	icmp6Type = "icmpv6_type"
+	icmp6Code = "icmpv6_code"
 	ipv6DST   = "ipv6_dst"
 	ipv6SRC   = "ipv6_src"
 	ipv6Label = "ipv6_label"
@@ -467,6 +470,78 @@ func (m *icmpTypeMatch) MarshalText() ([]byte, error) {
 // GoString implements Match.
 func (m *icmpTypeMatch) GoString() string {
 	return fmt.Sprintf("ovs.ICMPType(%d)", m.typ)
+}
+
+// ICMPCode matches packets with the specified ICMP code
+func ICMPCode(code uint8) Match {
+	return &icmpCodeMatch{
+		code: code,
+	}
+}
+
+var _ Match = &icmpCodeMatch{}
+
+// An icmpCodeMatch is a Match returned by ICMPCode
+type icmpCodeMatch struct {
+	code uint8
+}
+
+// MarshalText implements Match.
+func (m *icmpCodeMatch) MarshalText() ([]byte, error) {
+	return bprintf("%s=%d", icmpCode, m.code), nil
+}
+
+// GoString implements Match.
+func (m *icmpCodeMatch) GoString() string {
+	return fmt.Sprintf("ovs.ICMPCode(%d)", m.code)
+}
+
+// ICMP6Type matches packets with the specified ICMP type matching typ.
+func ICMP6Type(typ uint8) Match {
+	return &icmp6TypeMatch{
+		typ: typ,
+	}
+}
+
+var _ Match = &icmp6TypeMatch{}
+
+// An icmpTypeMatch is a Match returned by ICMPType.
+type icmp6TypeMatch struct {
+	typ uint8
+}
+
+// MarshalText implements Match.
+func (m *icmp6TypeMatch) MarshalText() ([]byte, error) {
+	return bprintf("%s=%d", icmp6Type, m.typ), nil
+}
+
+// GoString implements Match.
+func (m *icmp6TypeMatch) GoString() string {
+	return fmt.Sprintf("ovs.ICMP6Type(%d)", m.typ)
+}
+
+// ICMP6Code matches packets with the specified ICMP type matching typ.
+func ICMP6Code(code uint8) Match {
+	return &icmp6CodeMatch{
+		code: code,
+	}
+}
+
+var _ Match = &icmp6CodeMatch{}
+
+// An icmpCodeMatch is a Match returned by ICMP6Code
+type icmp6CodeMatch struct {
+	code uint8
+}
+
+// MarshalText implements Match.
+func (m *icmp6CodeMatch) MarshalText() ([]byte, error) {
+	return bprintf("%s=%d", icmp6Code, m.code), nil
+}
+
+// GoString implements Match.
+func (m *icmp6CodeMatch) GoString() string {
+	return fmt.Sprintf("ovs.ICMP6Code(%d)", m.code)
 }
 
 // InPortMatch matches packets ingressing from a specified OVS port

--- a/ovs/matchparser.go
+++ b/ovs/matchparser.go
@@ -31,7 +31,7 @@ func parseMatch(key string, value string) (Match, error) {
 		return parseMACMatch(key, value)
 	case arpOp:
 		return parseArpOp(value)
-	case icmpType, nwProto:
+	case icmpType, icmpCode, icmp6Type, icmp6Code, nwProto:
 		return parseIntMatch(key, value, math.MaxUint8)
 	case ctZone:
 		return parseIntMatch(key, value, math.MaxUint16)
@@ -120,6 +120,12 @@ func parseIntMatch(key string, value string, max int) (Match, error) {
 	switch key {
 	case icmpType:
 		return ICMPType(uint8(t)), nil
+	case icmpCode:
+		return ICMPCode(uint8(t)), nil
+	case icmp6Type:
+		return ICMP6Type(uint8(t)), nil
+	case icmp6Code:
+		return ICMP6Code(uint8(t)), nil
 	case inPort:
 		return InPortMatch(int(t)), nil
 	case nwECN:

--- a/ovs/matchparser_test.go
+++ b/ovs/matchparser_test.go
@@ -136,12 +136,24 @@ func Test_parseMatch(t *testing.T) {
 			m: ICMPType(1),
 		},
 		{
+			s: "icmp_code=1",
+			m: ICMPCode(1),
+		},
+		{
 			s: "ipv6_src=2001:db8::1",
 			m: IPv6Source("2001:db8::1"),
 		},
 		{
 			s: "ipv6_dst=2001:db8::1",
 			m: IPv6Destination("2001:db8::1"),
+		},
+		{
+			s: "icmpv6_type=135",
+			m: ICMP6Type(135),
+		},
+		{
+			s: "icmpv6_code=0",
+			m: ICMP6Code(0),
 		},
 		{
 			s:       "nd_sll=foo",

--- a/ovsnl/datapath.go
+++ b/ovsnl/datapath.go
@@ -109,7 +109,7 @@ func (s *DatapathService) List() ([]Datapath, error) {
 		}),
 	}
 
-	flags := netlink.HeaderFlagsRequest | netlink.HeaderFlagsDump
+	flags := netlink.Request | netlink.Dump
 	msgs, err := s.c.c.Execute(req, s.f.ID, flags)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Updated ICMPv6 code and type to ovs match so that ovs-appctl ofproto/trace can support icmpv6.

Fix for Travis-CI build. Removed HeaderFlags prefix based on netlink's recent change:
https://github.com/mdlayher/netlink/commit/080e8e36878e0f73c5a28fb285527eefe3603390#diff-b95c50d14ed7b4bb1cfecdc4e498d4dcL64