### PR TITLE
Parse the special LOCAL port correctly in ofproto/trace flows

### DIFF
--- a/ovs/proto_trace.go
+++ b/ovs/proto_trace.go
@@ -35,9 +35,10 @@ var (
 )
 
 const (
-	popvlan  = "popvlan"
-	pushvlan = "pushvlan"
-	drop     = "drop"
+	popvlan   = "popvlan"
+	pushvlan  = "pushvlan"
+	drop      = "drop"
+	localPort = 65534
 )
 
 // DataPathActions is a text unmarshaler for data path actions in ofproto/trace output
@@ -84,6 +85,15 @@ func (df *DataPathFlows) UnmarshalText(b []byte) error {
 		kv := strings.Split(match, "=")
 		if len(kv) != 2 {
 			return fmt.Errorf("unexpected match format for match %q", match)
+		}
+
+		switch strings.TrimSpace(kv[0]) {
+		case inPort:
+			// Parse in_port=LOCAL into a new match.
+			if strings.TrimSpace(kv[1]) == portLOCAL {
+				df.Matches = append(df.Matches, InPortMatch(localPort))
+				continue
+			}
 		}
 
 		m, err := parseMatch(kv[0], kv[1])

--- a/ovs/proto_trace_test.go
+++ b/ovs/proto_trace_test.go
@@ -42,6 +42,22 @@ Datapath actions: 1`,
 			actions: NewDataPathActions("1"),
 		},
 		{
+			name: "in_port is LOCAL",
+			output: `Flow: tcp,in_port=LOCAL,vlan_tci=0x0000,dl_src=00:00:00:00:00:00,dl_dst=00:00:00:00:00:00,nw_src=192.0.2.2,nw_dst=0.0.0.0,nw_tos=0,nw_ecn=0,nw_ttl=0,tp_src=0,tp_dst=22,tcp_flags=0
+
+bridge("br0")
+-------------
+ 0. ip,in_port=LOCAL,nw_src=192.0.2.0/24, priority 32768
+    resubmit(,2)
+ 2. tcp,tp_dst=22, priority 32768
+    output:1
+
+Final flow: unchanged
+Megaflow: recirc_id=0,tcp,in_port=LOCAL,nw_src=192.0.2.0/24,nw_frag=no,tp_dst=22
+Datapath actions: 1`,
+			actions: NewDataPathActions("1"),
+		},
+		{
 			name: "popvlan and output port",
 			output: `Flow: tcp,in_port=3,vlan_tci=0x0000,dl_src=00:00:00:00:00:00,dl_dst=00:00:00:00:00:00,nw_src=192.0.2.2,nw_dst=0.0.0.0,nw_tos=0,nw_ecn=0,nw_ttl=0,tp_src=0,tp_dst=22,tcp_flags=0
 


### PR DESCRIPTION
LOCAL is equivalent to 65534 according to OVS docs [1].

[1] https://www.mankier.com/7/ovs-fields#Metadata_Fields