### PR TITLE
add metadata match

### DIFF
--- a/ovs/match.go
+++ b/ovs/match.go
@@ -56,6 +56,7 @@ const (
 	ipv6DST   = "ipv6_dst"
 	ipv6SRC   = "ipv6_src"
 	ipv6Label = "ipv6_label"
+	metadata  = "metadata"
 	ndSLL     = "nd_sll"
 	ndTLL     = "nd_tll"
 	ndTarget  = "nd_target"
@@ -1210,6 +1211,30 @@ func (m *tunnelIDMatch) MarshalText() ([]byte, error) {
 	}
 
 	return bprintf("%s=%#x/%#x", tunID, m.id, m.mask), nil
+}
+
+// Metadata returns a Match that matches the given metadata value.
+func Metadata(m uint64) Match {
+	return &metadataMatch{
+		m: m,
+	}
+}
+
+var _ Match = &metadataMatch{}
+
+// A metadataMatch is a Match against a metadata value.
+type metadataMatch struct {
+	m uint64
+}
+
+// GoString implements Match.
+func (m *metadataMatch) GoString() string {
+	return fmt.Sprintf("ovs.Metadata(%#x)", m.m)
+}
+
+// MarshalText implements Match.
+func (m *metadataMatch) MarshalText() ([]byte, error) {
+	return bprintf("%s=%#x", metadata, m.m), nil
 }
 
 // matchIPv4AddressOrCIDR attempts to create a Match using the specified key

--- a/ovs/match_test.go
+++ b/ovs/match_test.go
@@ -1187,6 +1187,39 @@ func TestMatchTunnelID(t *testing.T) {
 	}
 }
 
+func TestMatchMetadata(t *testing.T) {
+	var tests = []struct {
+		desc string
+		m    Match
+		out  string
+	}{
+		{
+			desc: "metadata 0xa",
+			m:    Metadata(0xa),
+			out:  "metadata=0xa",
+		},
+		{
+			desc: "metadata max 64 bit",
+			m:    Metadata(0xffffffffffffffff),
+			out:  "metadata=0xffffffffffffffff",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			out, err := tt.m.MarshalText()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if want, got := tt.out, string(out); want != got {
+				t.Fatalf("unexpected Match output:\n- want: %q\n-  got: %q",
+					want, got)
+			}
+		})
+	}
+}
+
 func TestMatchGoString(t *testing.T) {
 	var tests = []struct {
 		m Match


### PR DESCRIPTION
I confirmed that this syntax is supported locally.
```
root@s2r3node2:/home/mbenami# ovs-ofctl --version
ovs-ofctl (Open vSwitch) 2.7.3
OpenFlow versions 0x1:0x4

root@s2r3node2:/home/mbenami# ovs-ofctl dump-flows mzb | grep metadata
 cookie=0x0, duration=2209.774s, table=0, n_packets=0, n_bytes=0, idle_age=2209, priority=800,arp,metadata=0x12 actions=group:809
```

uint64 data type selected in reference to REGISTER FIELDS section of this document
http://www.openvswitch.org/support/dist-docs/ovs-fields.7.txt