### PR TITLE
Save ovs-appctl command for reference by callers

### DIFF
--- a/ovs/app.go
+++ b/ovs/app.go
@@ -15,6 +15,7 @@
 package ovs
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -42,12 +43,15 @@ func (a *AppService) ProtoTrace(bridge string, protocol Protocol, matches []Matc
 	}
 
 	matchArg := strings.Join(matchFlows, ",")
-	out, err := a.exec("ofproto/trace", bridge, matchArg)
+	args := []string{"ofproto/trace", bridge, matchArg}
+	out, err := a.exec(args...)
 	if err != nil {
 		return nil, err
 	}
 
-	pt := &ProtoTrace{}
+	pt := &ProtoTrace{
+		CommandStr: fmt.Sprintf("ovs-appctl %s", strings.Join(args, " ")),
+	}
 	err = pt.UnmarshalText(out)
 	if err != nil {
 		return nil, err

--- a/ovs/proto_trace.go
+++ b/ovs/proto_trace.go
@@ -109,6 +109,7 @@ func (df *DataPathFlows) UnmarshalText(b []byte) error {
 
 // ProtoTrace is a type representing output from ovs-app-ctl ofproto/trace
 type ProtoTrace struct {
+	CommandStr      string
 	InputFlow       *DataPathFlows
 	FinalFlow       *DataPathFlows
 	DataPathActions DataPathActions


### PR DESCRIPTION
It can help to know the precise ovs-appctl command to run so that it
can be run manually.