### PR TITLE
add FieldMatch

### DIFF
--- a/ovs/match.go
+++ b/ovs/match.go
@@ -1346,3 +1346,28 @@ func (m *ipFragMatch) GoString() string {
 func (m *ipFragMatch) MarshalText() ([]byte, error) {
 	return bprintf("%s=%s", ipFrag, m.flag), nil
 }
+
+// FieldMatch returns an fieldMatch.
+func FieldMatch(field, srcOrValue string) Match {
+	return &fieldMatch{field: field, srcOrValue: srcOrValue}
+}
+
+// fieldMatch implements the Match interface and
+// matches a given field against another a value, e.g. "0x123" or "1.2.3.4",
+// or against another src field in the packet, e.g "arp_tpa" or "NXM_OF_ARP_TPA[]".
+type fieldMatch struct {
+	field      string
+	srcOrValue string
+}
+
+var _ Match = &fieldMatch{}
+
+// GoString implements Match.
+func (m *fieldMatch) GoString() string {
+	return fmt.Sprintf("ovs.FieldMatch(%v,%v)", m.field, m.srcOrValue)
+}
+
+// MarshalText implements Match.
+func (m *fieldMatch) MarshalText() ([]byte, error) {
+	return bprintf("%s=%s", m.field, m.srcOrValue), nil
+}

--- a/ovs/match_test.go
+++ b/ovs/match_test.go
@@ -1463,6 +1463,48 @@ func TestMatchIPFrag(t *testing.T) {
 	}
 }
 
+func TestMatchFieldMatch(t *testing.T) {
+	var tests = []struct {
+		desc       string
+		field      string
+		srcOrValue string
+		out        string
+	}{
+		{
+			desc:       "match on src field",
+			field:      "nw_src",
+			srcOrValue: "nw_dst",
+			out:        "nw_src=nw_dst",
+		},
+		{
+			desc:       "match on literal value hex",
+			field:      "dl_type",
+			srcOrValue: "0x0800",
+			out:        "dl_type=0x0800",
+		},
+		{
+			desc:       "match on literal IP address",
+			field:      "nw_dst",
+			srcOrValue: "1.2.3.4",
+			out:        "nw_dst=1.2.3.4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			out, err := FieldMatch(tt.field, tt.srcOrValue).MarshalText()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if want, got := tt.out, string(out); want != got {
+				t.Fatalf("unexpected Match output:\n- want: %q\n-  got: %q",
+					want, got)
+			}
+		})
+	}
+}
+
 // mustParseMAC is a helper to parse a hardware address from a string using
 // net.ParseMAC, that panic on failure.
 func mustParseMAC(addr string) net.HardwareAddr {


### PR DESCRIPTION
This match can be used inside of a learn action.

```
              field=value
                     Specifies that field, in the new  flow,  must  match  the
                     literal  value,  e.g. dl_type=0x800. Shorthand match syn‐
                     tax, such as ip in place of dl_type=0x800,  is  not  sup‐
                     ported.

              field=src
                     Specifies that field in the new flow must match src taken
                     from the packet currently being processed.  For  example,
                     udp_dst=udp_src, applied to a UDP packet with source port
                     53, creates a flow which matches  udp_dst=53.  field  and
                     src must have the same width.
```

from "learn action" section in ovs-actions man page: http://www.openvswitch.org/support/dist-docs/ovs-actions.7.txt