### PR TITLE
add Move action

### DIFF
--- a/ovs/action.go
+++ b/ovs/action.go
@@ -61,6 +61,9 @@ var (
 	// errTooManyDimensions is returned when the specified dimension exceeds the total dimension
 	// in a conjunction action.
 	errDimensionTooLarge = errors.New("dimension number exceeds total number of dimensions")
+
+	// errMoveEmpty is returned when Move is called with src and/or dst set to the empty string.
+	errMoveEmpty = errors.New("src and/or dst field for action move are empty")
 )
 
 // Action strings in lower case, as those are compared to the lower case letters
@@ -578,6 +581,34 @@ func (a *setTunnelAction) GoString() string {
 // MarshalText implements Action.
 func (a *setTunnelAction) MarshalText() ([]byte, error) {
 	return bprintf("set_tunnel:%#x", a.tunnelID), nil
+}
+
+// Move sets the value of the destination field to the value of the source field.
+func Move(src, dst string) Action {
+	return &moveAction{
+		src: src,
+		dst: dst,
+	}
+}
+
+// A moveAction is an Action used by Move.
+type moveAction struct {
+	src string
+	dst string
+}
+
+// GoString implements Action.
+func (a *moveAction) GoString() string {
+	return fmt.Sprintf("ovs.Move(%q, %q)", a.src, a.dst)
+}
+
+// MarshalText implements Action.
+func (a *moveAction) MarshalText() ([]byte, error) {
+	if a.src == "" || a.dst == "" {
+		return nil, errMoveEmpty
+	}
+
+	return bprintf("move:%s->%s", a.src, a.dst), nil
 }
 
 // validARPOP indicates if an ARP OP is out of range. It should be in the range

--- a/ovs/action_test.go
+++ b/ovs/action_test.go
@@ -579,6 +579,54 @@ func TestConjunction(t *testing.T) {
 	}
 }
 
+func TestMove(t *testing.T) {
+	var tests = []struct {
+		desc   string
+		a      Action
+		action string
+		err    error
+	}{
+		{
+			desc:   "move OK",
+			a:      Move("nw_src", "nw_dst"),
+			action: "move:nw_src->nw_dst",
+		},
+		{
+			desc: "both empty",
+			a:    Move("", ""),
+			err:  errMoveEmpty,
+		},
+		{
+			desc: "src empty",
+			a:    Move("", "nw_dst"),
+			err:  errMoveEmpty,
+		},
+		{
+			desc: "dst empty",
+			a:    Move("nw_src", ""),
+			err:  errMoveEmpty,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			action, err := tt.a.MarshalText()
+
+			if want, got := tt.err, err; want != got {
+				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+			if err != nil {
+				return
+			}
+
+			if want, got := tt.action, string(action); want != got {
+				t.Fatalf("unexpected Action:\n- want: %q\n-  got: %q",
+					want, got)
+			}
+		})
+	}
+}
 func TestActionGoString(t *testing.T) {
 	tests := []struct {
 		a Action
@@ -651,6 +699,10 @@ func TestActionGoString(t *testing.T) {
 		{
 			a: Conjunction(123, 1, 2),
 			s: `ovs.Conjunction(123, 1, 2)`,
+		},
+		{
+			a: Move("nw_src", "nw_dst"),
+			s: `ovs.Move("nw_src", "nw_dst")`,
 		},
 	}
 


### PR DESCRIPTION
```
   The move action
       Syntax:
              move:src->dst

       Copies the named bits from field or subfield src to field  or  subfield
       dst. src and dst should fields or subfields in the syntax described un‐
       der ``Field Specifications’’ above. The two fields  or  subfields  must
       have the same width.
```

From http://www.openvswitch.org/support/dist-docs/ovs-actions.7.txt