### PR TITLE
add output:field action

### DIFF
--- a/ovs/action.go
+++ b/ovs/action.go
@@ -66,7 +66,7 @@ var (
 	errMoveEmpty = errors.New("src and/or dst field for action move are empty")
 
 	// errOutputFieldEmpty is returned when OutputField is called with field set to the empty string.
-	errOutputFieldEmpty = errors.New("field for action output (output=field syntax) is empty")
+	errOutputFieldEmpty = errors.New("field for action output (output:field syntax) is empty")
 )
 
 // Action strings in lower case, as those are compared to the lower case letters

--- a/ovs/action.go
+++ b/ovs/action.go
@@ -64,6 +64,9 @@ var (
 
 	// errMoveEmpty is returned when Move is called with src and/or dst set to the empty string.
 	errMoveEmpty = errors.New("src and/or dst field for action move are empty")
+
+	// errOutputFieldEmpty is returned when OutputField is called with field set to the empty string.
+	errOutputFieldEmpty = errors.New("field for action output (output=field syntax) is empty")
 )
 
 // Action strings in lower case, as those are compared to the lower case letters
@@ -184,6 +187,7 @@ const (
 	patModTransportSourcePort      = "mod_tp_src:%d"
 	patModVLANVID                  = "mod_vlan_vid:%d"
 	patOutput                      = "output:%d"
+	patOutputField                 = "output:%s"
 	patResubmitPort                = "resubmit:%s"
 	patResubmitPortTable           = "resubmit(%s,%s)"
 )
@@ -401,6 +405,34 @@ func (a *outputAction) MarshalText() ([]byte, error) {
 // GoString implements Action.
 func (a *outputAction) GoString() string {
 	return fmt.Sprintf("ovs.Output(%d)", a.port)
+}
+
+// OutputField outputs the packet to the switch port described by the specified field.
+// For example, when the `field` value is "in_port", the packet is output to the port
+// it came in on.
+func OutputField(field string) Action {
+	return &outputFieldAction{
+		field: field,
+	}
+}
+
+// An outputFieldAction is an Action which is used by OutputField.
+type outputFieldAction struct {
+	field string
+}
+
+// MarshalText implements Action.
+func (a *outputFieldAction) MarshalText() ([]byte, error) {
+	if a.field == "" {
+		return nil, errOutputFieldEmpty
+	}
+
+	return bprintf(patOutputField, a.field), nil
+}
+
+// GoString implements Action.
+func (a *outputFieldAction) GoString() string {
+	return fmt.Sprintf("ovs.OutputField(%q)", a.field)
 }
 
 // Conjunction associates a flow with a certain conjunction ID to match on more than

--- a/ovs/action_test.go
+++ b/ovs/action_test.go
@@ -627,6 +627,46 @@ func TestMove(t *testing.T) {
 		})
 	}
 }
+
+func TestOutputField(t *testing.T) {
+	var tests = []struct {
+		desc   string
+		a      Action
+		action string
+		err    error
+	}{
+		{
+			desc:   "output field OK",
+			a:      OutputField("in_port"),
+			action: "output:in_port",
+		},
+		{
+			desc: "empty field",
+			a:    OutputField(""),
+			err:  errOutputFieldEmpty,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			action, err := tt.a.MarshalText()
+
+			if want, got := tt.err, err; want != got {
+				t.Fatalf("unexpected error:\n- want: %v\n-  got: %v",
+					want, got)
+			}
+			if err != nil {
+				return
+			}
+
+			if want, got := tt.action, string(action); want != got {
+				t.Fatalf("unexpected Action:\n- want: %q\n-  got: %q",
+					want, got)
+			}
+		})
+	}
+}
+
 func TestActionGoString(t *testing.T) {
 	tests := []struct {
 		a Action
@@ -703,6 +743,10 @@ func TestActionGoString(t *testing.T) {
 		{
 			a: Move("nw_src", "nw_dst"),
 			s: `ovs.Move("nw_src", "nw_dst")`,
+		},
+		{
+			a: OutputField("in_port"),
+			s: `ovs.OutputField("in_port")`,
 		},
 	}
 


### PR DESCRIPTION
```
              output:field
                     Adds an output action to the new flow’s actions that out‐
                     puts to the OpenFlow port taken from field, which must be
                     a field as described above.
```

The output:field syntax can be used both in normal `output` actions, as well as in an action inside a `learn` action. 

When used inside the `learn` action the `output:field` syntax is the only acceptable form.

http://www.openvswitch.org/support/dist-docs/ovs-actions.7.txt