### PR TITLE
ovsnl: add awareness for ovs_meter

### DIFF
--- a/ovsnl/client.go
+++ b/ovsnl/client.go
@@ -80,9 +80,9 @@ func (c *Client) Close() error {
 
 // init initializes the generic netlink family service of Client.
 func (c *Client) init(families []genetlink.Family) error {
-	// Assume 4 families present.
+	// Assume 5 families present.
 	var gotf int
-	const wantf = 4
+	const wantf = 5
 
 	for _, f := range families {
 		// Ignore any families without the OVS prefix.
@@ -118,7 +118,7 @@ func (c *Client) initFamily(f genetlink.Family) error {
 			c: c,
 		}
 		return nil
-	case ovsh.FlowFamily, ovsh.PacketFamily, ovsh.VportFamily:
+	case ovsh.FlowFamily, ovsh.PacketFamily, ovsh.VportFamily, ovsh.MeterFamily:
 		// TODO(mdlayher): populate.
 		return nil
 	}

--- a/ovsnl/client_linux_test.go
+++ b/ovsnl/client_linux_test.go
@@ -84,6 +84,7 @@ func TestClientOK(t *testing.T) {
 			ovsh.FlowFamily,
 			ovsh.PacketFamily,
 			ovsh.VportFamily,
+			ovsh.MeterFamily,
 		}), nil
 	})
 
@@ -127,6 +128,7 @@ func ovsFamilies(fn genltest.Func) genltest.Func {
 				ovsh.FlowFamily,
 				ovsh.PacketFamily,
 				ovsh.VportFamily,
+				ovsh.MeterFamily,
 			}), nil
 		}
 


### PR DESCRIPTION
Quick PR to get master green again.  It appears this netlink family is being returned now in integration tests, where it wasn't previously.  Meant to unblock @btsomogyi 