### PR TITLE
ovsnl: only fail if no known families are found

### DIFF
--- a/ovsnl/client.go
+++ b/ovsnl/client.go
@@ -87,11 +87,11 @@ func (c *Client) init(families []genetlink.Family) error {
 		if !strings.HasPrefix(f.Name, "ovs_") {
 			continue
 		}
-
-		gotf++
+		// Ignore any families that might be unknown.
 		if err := c.initFamily(f); err != nil {
-			return err
+			continue
 		}
+		gotf++
 	}
 
 	// No known families; return error for os.IsNotExist check.
@@ -113,7 +113,7 @@ func (c *Client) initFamily(f genetlink.Family) error {
 		return nil
 	default:
 		// Unknown OVS netlink family, nothing we can do.
-		return nil
+		return fmt.Errorf("unknown OVS generic netlink family: %q", f.Name)
 	}
 }
 

--- a/ovsnl/client.go
+++ b/ovsnl/client.go
@@ -80,9 +80,7 @@ func (c *Client) Close() error {
 
 // init initializes the generic netlink family service of Client.
 func (c *Client) init(families []genetlink.Family) error {
-	// Assume 5 families present.
 	var gotf int
-	const wantf = 5
 
 	for _, f := range families {
 		// Ignore any families without the OVS prefix.
@@ -96,14 +94,9 @@ func (c *Client) init(families []genetlink.Family) error {
 		}
 	}
 
-	// No families; return error for os.IsNotExist check.
+	// No known families; return error for os.IsNotExist check.
 	if gotf == 0 {
 		return os.ErrNotExist
-	}
-
-	if gotf != wantf {
-		return fmt.Errorf("expected %d OVS generic netlink families, but found %d",
-			wantf, gotf)
 	}
 
 	return nil
@@ -118,12 +111,10 @@ func (c *Client) initFamily(f genetlink.Family) error {
 			c: c,
 		}
 		return nil
-	case ovsh.FlowFamily, ovsh.PacketFamily, ovsh.VportFamily, ovsh.MeterFamily:
-		// TODO(mdlayher): populate.
+	default:
+		// Unknown OVS netlink family, nothing we can do.
 		return nil
 	}
-
-	return fmt.Errorf("unrecognized OVS generic netlink family: %q", f.Name)
 }
 
 // headerBytes converts an ovsh.Header into a byte slice.

--- a/ovsnl/client_linux_test.go
+++ b/ovsnl/client_linux_test.go
@@ -46,27 +46,10 @@ func TestClientNoFamiliesIsNotExist(t *testing.T) {
 	t.Logf("OK error: %v", err)
 }
 
-func TestClientInvalidFamily(t *testing.T) {
-	conn := genltest.Dial(func(greq genetlink.Message, nreq netlink.Message) ([]genetlink.Message, error) {
-		return familyMessages([]string{
-			"ovs_foo",
-		}), nil
-	})
-
-	_, err := newClient(conn)
-	if err == nil {
-		t.Fatalf("expected an error, but none occurred")
-	}
-
-	t.Logf("OK error: %v", err)
-}
-
-func TestClientMissingFamilies(t *testing.T) {
+func TestClientNoKnownFamilies(t *testing.T) {
 	conn := genltest.Dial(func(greq genetlink.Message, nreq netlink.Message) ([]genetlink.Message, error) {
 		// Too few OVS families.
-		return familyMessages([]string{
-			ovsh.DatapathFamily,
-		}), nil
+		return nil, nil
 	})
 
 	_, err := newClient(conn)
@@ -77,14 +60,10 @@ func TestClientMissingFamilies(t *testing.T) {
 	t.Logf("OK error: %v", err)
 }
 
-func TestClientOK(t *testing.T) {
+func TestClientKnownFamilies(t *testing.T) {
 	conn := genltest.Dial(func(greq genetlink.Message, nreq netlink.Message) ([]genetlink.Message, error) {
 		return familyMessages([]string{
 			ovsh.DatapathFamily,
-			ovsh.FlowFamily,
-			ovsh.PacketFamily,
-			ovsh.VportFamily,
-			ovsh.MeterFamily,
 		}), nil
 	})
 

--- a/ovsnl/client_linux_test.go
+++ b/ovsnl/client_linux_test.go
@@ -46,7 +46,22 @@ func TestClientNoFamiliesIsNotExist(t *testing.T) {
 	t.Logf("OK error: %v", err)
 }
 
-func TestClientNoKnownFamilies(t *testing.T) {
+func TestClientUnknownFamilies(t *testing.T) {
+	conn := genltest.Dial(func(greq genetlink.Message, nreq netlink.Message) ([]genetlink.Message, error) {
+		return familyMessages([]string{
+			"ovs_foo",
+		}), nil
+	})
+
+	_, err := newClient(conn)
+	if err == nil {
+		t.Fatalf("expected an error, but none occurred")
+	}
+
+	t.Logf("OK error: %v", err)
+}
+
+func TestClientNoFamilies(t *testing.T) {
 	conn := genltest.Dial(func(greq genetlink.Message, nreq netlink.Message) ([]genetlink.Message, error) {
 		// Too few OVS families.
 		return nil, nil


### PR DESCRIPTION
Before this commit the ovnl client logic was such that it needs to be
kept in lock-step synchronization with a particular version of the
netlink interface. This is too fragile, as each new update requires
touching this logic, which in turn makes it non-backward compatible.

This commit flips the logic on its head and instead makes the client
complains only if no 'known' families are found. This makes the init
logic future proof and backward compatible.