### PR TITLE
add BridgeToParent to VSwitchService

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -13,3 +13,4 @@ Tejas Kokje <tkokje@digitalocean.com>
 Kei Nohguchi <knohguchi@digitalocean.com>
 Neal Shrader <nshrader@digitalocean.com>
 Sangeetha Srikanth <ssrikanth@digitalocean.com>
+John Oberly III <joberly@gmail.com>

--- a/ovs/vswitch.go
+++ b/ovs/vswitch.go
@@ -56,6 +56,17 @@ func (v *VSwitchService) AddPort(bridge string, port string) error {
 	return err
 }
 
+// BridgeToParent returns the parent bridge of a bridge on Open vSwitch.
+// If a bridge has no parent, it returns the bridge from the call.
+func (v *VSwitchService) BridgeToParent(bridge string) (string, error) {
+	out, err := v.exec("br-to-parent", bridge)
+	if err != nil {
+		return "", err
+	}
+
+	return string(out), nil
+}
+
 // DeleteBridge detaches a bridge from Open vSwitch.  The bridge may or may
 // not already exist.
 func (v *VSwitchService) DeleteBridge(bridge string) error {

--- a/ovs/vswitch_test.go
+++ b/ovs/vswitch_test.go
@@ -74,6 +74,41 @@ func TestClientVSwitchAddPortOK(t *testing.T) {
 	}
 }
 
+func TestClientVSwitchBridgeToParentOK(t *testing.T) {
+	br := "br0-1"
+	wantBr := "br0"
+
+	// Add Timeout option to verify arguments
+	c := testClient([]OptionFunc{Timeout(1)}, func(cmd string, args ...string) ([]byte, error) {
+		// Verify command
+		if want, got := "ovs-vsctl", cmd; want != got {
+			t.Fatalf("incorrect command:\n- want: %v\n-  got: %v",
+				want, got)
+		}
+
+		// Verify arguments including option flags
+		wantArgs := []string{"--timeout=1", "br-to-parent", br}
+		if want, got := wantArgs, args; !reflect.DeepEqual(want, got) {
+			t.Fatalf("incorrect arguments\n- want: %v\n-  got: %v",
+				want, got)
+		}
+
+		// Add whitespace to verify it is trimmed appropriately
+		return []byte("\n\n  " + wantBr + "\t\n "), nil
+	})
+
+	parentBr, err := c.VSwitch.BridgeToParent(br)
+	if err != nil {
+		t.Fatalf("unexpected error for Client.VSwitch.BridgeToParent: %v", err)
+	}
+
+	// Verify function return value
+	if want, got := wantBr, parentBr; want != got {
+		t.Fatalf("unexpected bridge:\n- want: %v\n-  got: %v",
+			want, got)
+	}
+}
+
 func TestClientVSwitchDeleteBridgeOK(t *testing.T) {
 	bridge := "br0"
 


### PR DESCRIPTION
Adds support for the ovs-vsctl br-to-parent command.