### PR TITLE
ovs: allow for MTU configuration of interfaces

### DIFF
--- a/ovs/vswitch.go
+++ b/ovs/vswitch.go
@@ -236,6 +236,10 @@ type InterfaceOptions struct {
 	// Peer specifies an interface to peer with when creating a patch interface.
 	Peer string
 
+	// MTURequest specifies the maximum transmission unit associated with an
+	// interface.
+	MTURequest int
+
 	// Ingress Policing
 	//
 	// These settings control ingress policing for packets received on this
@@ -283,6 +287,10 @@ func (i InterfaceOptions) slice() []string {
 
 	if i.Peer != "" {
 		s = append(s, fmt.Sprintf("options:peer=%s", i.Peer))
+	}
+
+	if i.MTURequest > 0 {
+		s = append(s, fmt.Sprintf("mtu_request=%d", i.MTURequest))
 	}
 
 	if i.IngressRatePolicing == DefaultIngressRatePolicing {

--- a/ovs/vswitch_test.go
+++ b/ovs/vswitch_test.go
@@ -656,6 +656,7 @@ func TestClientVSwitchSetInterfaceOK(t *testing.T) {
 	peer := "eth0"
 	ratePolicing := DefaultIngressRatePolicing
 	burstPolicing := DefaultIngressBurstPolicing
+	requestedMTU := 9000
 
 	// Apply Timeout option to verify arguments
 	c := testClient([]OptionFunc{Timeout(1)}, func(cmd string, args ...string) ([]byte, error) {
@@ -672,6 +673,7 @@ func TestClientVSwitchSetInterfaceOK(t *testing.T) {
 			string(ifi),
 			fmt.Sprintf("type=%s", ifiType),
 			fmt.Sprintf("options:peer=%s", peer),
+			"mtu_request=9000",
 			"ingress_policing_rate=0",
 			"ingress_policing_burst=0",
 		}
@@ -688,6 +690,7 @@ func TestClientVSwitchSetInterfaceOK(t *testing.T) {
 		Peer:                 peer,
 		IngressRatePolicing:  ratePolicing,
 		IngressBurstPolicing: burstPolicing,
+		MTURequest:           requestedMTU,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error for Client.VSwitch.Set.Interface: %v", err)
@@ -788,6 +791,15 @@ func TestInterfaceOptions_slice(t *testing.T) {
 			},
 		},
 		{
+			desc: "only MTURequest",
+			i: InterfaceOptions{
+				MTURequest: 9000,
+			},
+			out: []string{
+				"mtu_request=9000",
+			},
+		},
+		{
 			desc: "only ingress policing rate",
 			i: InterfaceOptions{
 				IngressRatePolicing: 2000000,
@@ -852,10 +864,12 @@ func TestInterfaceOptions_slice(t *testing.T) {
 				Peer:                 "bond0",
 				IngressRatePolicing:  2000000,
 				IngressBurstPolicing: 200000,
+				MTURequest:           9000,
 			},
 			out: []string{
 				"type=patch",
 				"options:peer=bond0",
+				"mtu_request=9000",
 				"ingress_policing_rate=2000000",
 				"ingress_policing_burst=200000",
 			},


### PR DESCRIPTION
This allows us to alter the MTU of interfaces managed by OVS beyond their default values.