### PR TITLE
ovs: add action parser for move

### DIFF
--- a/ovs/actionparser.go
+++ b/ovs/actionparser.go
@@ -160,6 +160,10 @@ var (
 	// with its parameters.
 	loadRe = regexp.MustCompile(`load:(\S+)->(\S+)`)
 
+	// moveRe is the regex used to match the move action
+	// with its parameters.
+	moveRe = regexp.MustCompile(`move:(\S+)->(\S+)`)
+
 	// setFieldRe is the regex used to match the set_field action
 	// with its parameters.
 	setFieldRe = regexp.MustCompile(`set_field:(\S+)->(\S+)`)
@@ -367,6 +371,14 @@ func parseAction(s string) (Action, error) {
 		//  - value
 		//  - field
 		return Load(ss[0][1], ss[0][2]), nil
+	}
+
+	if ss := moveRe.FindAllStringSubmatch(s, 2); len(ss) > 0 && len(ss[0]) == 3 {
+		// Results are:
+		//  - full string
+		//  - value
+		//  - field
+		return Move(ss[0][1], ss[0][2]), nil
 	}
 
 	if ss := setFieldRe.FindAllStringSubmatch(s, 2); len(ss) > 0 && len(ss[0]) == 3 {

--- a/ovs/actionparser_test.go
+++ b/ovs/actionparser_test.go
@@ -270,6 +270,18 @@ func Test_parseAction(t *testing.T) {
 			a: Load("0x2", "NXM_OF_ARP_OP[]"),
 		},
 		{
+			s:       "move:->NXM_OF_ARP_OP[]",
+			invalid: true,
+		},
+		{
+			s:       "move:NXM_OF_ARP_SPA[]->",
+			invalid: true,
+		},
+		{
+			s: "move:NXM_OF_ARP_SPA[]->NXM_OF_ARP_TPA[]",
+			a: Move("move:NXM_OF_ARP_SPA[]", "NXM_OF_ARP_TPA[]"),
+		},
+		{
 			s:       "set_field:->arp_spa",
 			invalid: true,
 		},


### PR DESCRIPTION
The `move` action was implemented in this library:

https://github.com/digitalocean/go-openvswitch/blob/master/ovs/action.go#L622-L648

However, we're missing a companion parser for this action to allow flows with this action to be properly read.  This PR adds that to allow them to be properly read.