### PR TITLE
fea: df_default options for vxlan.

### DIFF
--- a/ovs/vswitch.go
+++ b/ovs/vswitch.go
@@ -274,6 +274,9 @@ type InterfaceOptions struct {
 	// tunneled traffic leaving this interface. Optionally it could be set to
 	// "flow" which expects the flow to set tunnel ID.
 	Key string
+
+	// Flags indicat whether allowed fragments packets in IP Header.
+	DfDefault string
 }
 
 // slice creates a string slice containing any non-zero option values from the
@@ -313,6 +316,10 @@ func (i InterfaceOptions) slice() []string {
 
 	if i.Key != "" {
 		s = append(s, fmt.Sprintf("options:key=%s", i.Key))
+	}
+
+	if i.DfDefault != "" {
+		s = append(s, fmt.Sprintf("options:df_default=%s", i.DfDefault))
 	}
 
 	return s

--- a/ovs/vswitch.go
+++ b/ovs/vswitch.go
@@ -275,8 +275,18 @@ type InterfaceOptions struct {
 	// "flow" which expects the flow to set tunnel ID.
 	Key string
 
-	// Flags indicat whether allowed fragments packets in IP Header.
+	// Specifies the usage of the Don't Fragment flag (DF) bit in outgoing packets
+	// with IPv4 headers. The value inherit causes the bit to be copied from
+	// the original IP header. The values unset and set cause the bit to be always unset
+	// or always set, respectively. By default, the bit is not set.
 	DfDefault string
+
+	// Specifies the source IP address to use in outgoing packets.
+	LocalIP string
+
+	// Specifies the UDP destination port to communicate to the remote
+	// VXLAN tunnel endpoint.
+	DstPort uint32
 }
 
 // slice creates a string slice containing any non-zero option values from the
@@ -320,6 +330,14 @@ func (i InterfaceOptions) slice() []string {
 
 	if i.DfDefault != "" {
 		s = append(s, fmt.Sprintf("options:df_default=%s", i.DfDefault))
+	}
+
+	if i.LocalIP != "" {
+		s = append(s, fmt.Sprintf("options:local_ip=%s", i.LocalIP))
+	}
+
+	if i.DstPort > 0 {
+		s = append(s, fmt.Sprintf("options:dst_port=%d", i.DstPort))
 	}
 
 	return s


### PR DESCRIPTION
allowed configure df_default options for vxlan port, like the following:
``` Bridge br-tun
        fail_mode: secure
        Port "vx-100650118"
            Interface "vx-100650118"
                type: vxlan
                options: {df_default="false", key=flow, remote_ip="100.65.0.118"}
        Port "vx-100650119"
            Interface "vx-100650119"
                type: vxlan
                options: {df_default="false", key=flow, remote_ip="100.65.0.119"}
        Port br-tun
            Interface br-tun

```