### PR TITLE
Add github action CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,51 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.15
+
+    - name: OVS setup
+      run: |
+        sudo apt install openvswitch-switch
+        sudo ovs-vsctl add-br ovsbr0
+        
+    - name: Get tooling
+      run: |
+        go get golang.org/x/lint/golint
+        go get honnef.co/go/tools/cmd/staticcheck
+        go get -d ./...
+        
+    - name: License check
+      run: ./scripts/licensecheck.sh
+        
+    - name: Build
+      run: go build -v -tags=gofuzz ./...
+
+    - name: vet
+      run: go vet ./...
+
+    - name: staticcheck
+      run: staticcheck ./...
+
+    - name: lint
+      run: golint -set_exit_status ./cmd/... ./internal/...
+
+    - name: Test
+      run: |
+        go test -v -race ./...
+        go test -c -race ./ovsdb
+        sudo ./ovsdb.test -test.v


### PR DESCRIPTION
- Travis CI seems to not be triggered anymore when a PR is submitted. Aslo Travis looks slow compared to github action.

- In order to get rid of `Travis CI` and move to `github action`  I propose this flow.

- This is basically all tasks from the `.travis.yaml` ported to github action, the only change made is the `golang` version from `1.12` to `1.15`

- Question we still make use of golint but it is deprecated as reported to its page https://github.com/golang/lint do we want to get it rid of it too?