### PR TITLE
Update go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,8 @@ jobs:
 
     - name: OVS setup
       run: |
-        sudo apt install openvswitch-switch
+        sudo apt-get install
+        sudo apt install -y openvswitch-switch
         sudo ovs-vsctl add-br ovsbr0
         
     - name: Check and test


### PR DESCRIPTION
The Ci is broken due to an error while installing openvswitch through the debian packages.
In order to avoid broken links, we must update the repositories before running the installation