### PR TITLE
Update go.yml

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,6 +20,7 @@ jobs:
 
     - name: OVS setup
       run: |
+       sudo apt-get update
         sudo apt install openvswitch-switch
         sudo ovs-vsctl add-br ovsbr0
         


### PR DESCRIPTION
The Ci is broken due to an error while installing openvswitch through the debian packages.
In order to avoid broken links, we must update the repositories before running the installation