### PR TITLE
save output of ofproto/trace

### DIFF
--- a/ovs/app.go
+++ b/ovs/app.go
@@ -52,6 +52,7 @@ func (a *AppService) ProtoTrace(bridge string, protocol Protocol, matches []Matc
 
 	pt := &ProtoTrace{
 		CommandStr: fmt.Sprintf("ovs-appctl %s", strings.Join(args, " ")),
+		RawOutput:  out,
 	}
 	err = pt.UnmarshalText(out)
 	if err != nil {

--- a/ovs/proto_trace.go
+++ b/ovs/proto_trace.go
@@ -139,6 +139,7 @@ type ProtoTrace struct {
 	FinalFlow       *DataPathFlows
 	DataPathActions DataPathActions
 	FlowActions     []string
+	RawOutput       []byte
 }
 
 // UnmarshalText unmarshals ProtoTrace text into a ProtoTrace type.


### PR DESCRIPTION
The output isn't very large and it is useful to save it for verbose
output when callers want to inspect it as a whole.