### PR TITLE
 dumpPortsPrefix is shown multiple times on ovs with many ports

### DIFF
--- a/ovs/openflow.go
+++ b/ovs/openflow.go
@@ -431,6 +431,13 @@ func parseEach(in []byte, prefix []byte, fn func(b []byte) error) error {
 	// Scan every two lines to retrieve information needed to unmarshal
 	// a single PortStats struct.
 	for scanner.Scan() {
+
+		// After 630 ports the DumpPortsPrefix is shown again.
+		// Detect here to discover if we need to continue the loop.
+		if bytes.HasPrefix(scanner.Bytes(), prefix) {
+			continue
+		}
+
 		b := make([]byte, len(scanner.Bytes()))
 		copy(b, scanner.Bytes())
 


### PR DESCRIPTION
Greetings,

while using this library we found that the parsing of the ovs dumpPorts breaks when ovs has a lot of ports because the dumpPortsPrefix "OFPST_PORT reply" can be shown multiple times.

This patch adds a condition to check if we see the dumpPortsPrefix again to continue the loop without parsing it.