### PR TITLE
Add ability to match UDP source/destination ports

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -14,3 +14,4 @@ Kei Nohguchi <knohguchi@digitalocean.com>
 Neal Shrader <nshrader@digitalocean.com>
 Sangeetha Srikanth <ssrikanth@digitalocean.com>
 Franck Rupin <frupin@digitalocean.com>
+Adam Simeth <asimeth@digitalocean.com>

--- a/ovs/match.go
+++ b/ovs/match.go
@@ -917,8 +917,8 @@ func TransportDestinationMaskedPort(port uint16, mask uint16) Match {
 	}
 }
 
-// UdpSourcePort matches packets with a UDP source port matching port.
-func UdpSourcePort(port uint16) Match {
+// UDPSourcePort matches packets with a UDP source port matching port.
+func UDPSourcePort(port uint16) Match {
 	return &udpPortMatch{
 		srcdst: source,
 		port:   port,
@@ -926,8 +926,8 @@ func UdpSourcePort(port uint16) Match {
 	}
 }
 
-// UdpDestinationPort matches packets with a UDP destination port matching port.
-func UdpDestinationPort(port uint16) Match {
+// UDPDestinationPort matches packets with a UDP destination port matching port.
+func UDPDestinationPort(port uint16) Match {
 	return &udpPortMatch{
 		srcdst: destination,
 		port:   port,
@@ -935,8 +935,8 @@ func UdpDestinationPort(port uint16) Match {
 	}
 }
 
-// UdpSourceMaskedPort matches packets with UDP source port matching a masked port range.
-func UdpSourceMaskedPort(port uint16, mask uint16) Match {
+// UDPSourceMaskedPort matches packets with UDP source port matching a masked port range.
+func UDPSourceMaskedPort(port uint16, mask uint16) Match {
 	return &udpPortMatch{
 		srcdst: source,
 		port:   port,
@@ -944,8 +944,8 @@ func UdpSourceMaskedPort(port uint16, mask uint16) Match {
 	}
 }
 
-// UdpDestinationMaskedPort matches packets with a UDP destination port matching a masked port range.
-func UdpDestinationMaskedPort(port uint16, mask uint16) Match {
+// UDPDestinationMaskedPort matches packets with a UDP destination port matching a masked port range.
+func UDPDestinationMaskedPort(port uint16, mask uint16) Match {
 	return &udpPortMatch{
 		srcdst: destination,
 		port:   port,
@@ -969,8 +969,8 @@ type udpPortRange struct {
 	endPort   uint16
 }
 
-// UdpDestinationPortRange represent a port range intended for a UDP protocol destination port.
-func UdpDestinationPortRange(startPort uint16, endPort uint16) TransportPortRanger {
+// UDPDestinationPortRange represent a port range intended for a UDP protocol destination port.
+func UDPDestinationPortRange(startPort uint16, endPort uint16) TransportPortRanger {
 	return &udpPortRange{
 		srcdst:    destination,
 		startPort: startPort,
@@ -978,8 +978,8 @@ func UdpDestinationPortRange(startPort uint16, endPort uint16) TransportPortRang
 	}
 }
 
-// UdpSourcePortRange represent a port range intended for a UDP protocol source port.
-func UdpSourcePortRange(startPort uint16, endPort uint16) TransportPortRanger {
+// UDPSourcePortRange represent a port range intended for a UDP protocol source port.
+func UDPSourcePortRange(startPort uint16, endPort uint16) TransportPortRanger {
 	return &udpPortRange{
 		srcdst:    source,
 		startPort: startPort,
@@ -1015,7 +1015,7 @@ func (pr *udpPortRange) MaskedPorts() ([]Match, error) {
 
 // MarshalText implements Match.
 func (m *udpPortMatch) MarshalText() ([]byte, error) {
-	return matchUdpPort(m.srcdst, m.port, m.mask)
+	return matchUDPPort(m.srcdst, m.port, m.mask)
 }
 
 // GoString implements Match.
@@ -1607,9 +1607,9 @@ func matchTransportPort(srcdst string, port uint16, mask uint16) ([]byte, error)
 	return bprintf("tp_%s=0x%04x/0x%04x", srcdst, port, mask), nil
 }
 
-// matchUdpPort is the common implementation for
+// matchUDPPort is the common implementation for
 // Udp{Source,Destination}Port.
-func matchUdpPort(srcdst string, port uint16, mask uint16) ([]byte, error) {
+func matchUDPPort(srcdst string, port uint16, mask uint16) ([]byte, error) {
 	// No mask specified
 	if mask == 0 {
 		return bprintf("udp_%s=%d", srcdst, port), nil

--- a/ovs/match_test.go
+++ b/ovs/match_test.go
@@ -930,32 +930,32 @@ func TestMatchUdp(t *testing.T) {
 	}{
 		{
 			desc: "source port 80",
-			m:    UdpSourcePort(80),
+			m:    UDPSourcePort(80),
 			out:  "udp_src=80",
 		},
 		{
 			desc: "source port 65535",
-			m:    UdpSourcePort(65535),
+			m:    UDPSourcePort(65535),
 			out:  "udp_src=65535",
 		},
 		{
 			desc: "destination port 22",
-			m:    UdpDestinationPort(22),
+			m:    UDPDestinationPort(22),
 			out:  "udp_dst=22",
 		},
 		{
 			desc: "destination port 8080",
-			m:    UdpDestinationPort(8080),
+			m:    UDPDestinationPort(8080),
 			out:  "udp_dst=8080",
 		},
 		{
 			desc: "source port range 16/0xfff0 (16-31)",
-			m:    UdpSourceMaskedPort(0x10, 0xfff0),
+			m:    UDPSourceMaskedPort(0x10, 0xfff0),
 			out:  "udp_src=0x0010/0xfff0",
 		},
 		{
 			desc: "destination port range 16/0xfff0 (16-31)",
-			m:    UdpDestinationMaskedPort(0x10, 0xfff0),
+			m:    UDPDestinationMaskedPort(0x10, 0xfff0),
 			out:  "udp_dst=0x0010/0xfff0",
 		},
 	}
@@ -983,32 +983,32 @@ func TestMatchUdpPortRange(t *testing.T) {
 	}{
 		{
 			desc: "destination port range 16-31",
-			pr:   UdpDestinationPortRange(16, 31),
+			pr:   UDPDestinationPortRange(16, 31),
 			m: []Match{
-				UdpDestinationMaskedPort(0x10, 0xfff0),
+				UDPDestinationMaskedPort(0x10, 0xfff0),
 			},
 		},
 		{
 			desc: "source port range 16-31",
-			pr:   UdpSourcePortRange(16, 31),
+			pr:   UDPSourcePortRange(16, 31),
 			m: []Match{
-				UdpSourceMaskedPort(0x10, 0xfff0),
+				UDPSourceMaskedPort(0x10, 0xfff0),
 			},
 		},
 		{
 			desc: "destination port range 16-32",
-			pr:   UdpDestinationPortRange(16, 32),
+			pr:   UDPDestinationPortRange(16, 32),
 			m: []Match{
-				UdpDestinationMaskedPort(0x10, 0xfff0),
-				UdpDestinationMaskedPort(0x20, 0xffff),
+				UDPDestinationMaskedPort(0x10, 0xfff0),
+				UDPDestinationMaskedPort(0x20, 0xffff),
 			},
 		},
 		{
 			desc: "source port range 16-32",
-			pr:   UdpSourcePortRange(16, 32),
+			pr:   UDPSourcePortRange(16, 32),
 			m: []Match{
-				UdpSourceMaskedPort(0x10, 0xfff0),
-				UdpSourceMaskedPort(0x20, 0xffff),
+				UDPSourceMaskedPort(0x10, 0xfff0),
+				UDPSourceMaskedPort(0x20, 0xffff),
 			},
 		},
 	}

--- a/ovs/match_test.go
+++ b/ovs/match_test.go
@@ -922,6 +922,111 @@ func TestMatchTransportPortRange(t *testing.T) {
 	}
 }
 
+func TestMatchUdp(t *testing.T) {
+	var tests = []struct {
+		desc string
+		m    Match
+		out  string
+	}{
+		{
+			desc: "source port 80",
+			m:    UdpSourcePort(80),
+			out:  "udp_src=80",
+		},
+		{
+			desc: "source port 65535",
+			m:    UdpSourcePort(65535),
+			out:  "udp_src=65535",
+		},
+		{
+			desc: "destination port 22",
+			m:    UdpDestinationPort(22),
+			out:  "udp_dst=22",
+		},
+		{
+			desc: "destination port 8080",
+			m:    UdpDestinationPort(8080),
+			out:  "udp_dst=8080",
+		},
+		{
+			desc: "source port range 16/0xfff0 (16-31)",
+			m:    UdpSourceMaskedPort(0x10, 0xfff0),
+			out:  "udp_src=0x0010/0xfff0",
+		},
+		{
+			desc: "destination port range 16/0xfff0 (16-31)",
+			m:    UdpDestinationMaskedPort(0x10, 0xfff0),
+			out:  "udp_dst=0x0010/0xfff0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			out, err := tt.m.MarshalText()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if want, got := tt.out, string(out); want != got {
+				t.Fatalf("unexpected Match output:\n- want: %q\n-  got: %q",
+					want, got)
+			}
+		})
+	}
+}
+
+func TestMatchUdpPortRange(t *testing.T) {
+	var tests = []struct {
+		desc string
+		pr   TransportPortRanger
+		m    []Match
+	}{
+		{
+			desc: "destination port range 16-31",
+			pr:   UdpDestinationPortRange(16, 31),
+			m: []Match{
+				UdpDestinationMaskedPort(0x10, 0xfff0),
+			},
+		},
+		{
+			desc: "source port range 16-31",
+			pr:   UdpSourcePortRange(16, 31),
+			m: []Match{
+				UdpSourceMaskedPort(0x10, 0xfff0),
+			},
+		},
+		{
+			desc: "destination port range 16-32",
+			pr:   UdpDestinationPortRange(16, 32),
+			m: []Match{
+				UdpDestinationMaskedPort(0x10, 0xfff0),
+				UdpDestinationMaskedPort(0x20, 0xffff),
+			},
+		},
+		{
+			desc: "source port range 16-32",
+			pr:   UdpSourcePortRange(16, 32),
+			m: []Match{
+				UdpSourceMaskedPort(0x10, 0xfff0),
+				UdpSourceMaskedPort(0x20, 0xffff),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			m, err := tt.pr.MaskedPorts()
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if want, got := tt.m, m; !reflect.DeepEqual(want, got) {
+				t.Fatalf("unexpected Match:\n- want: %q\n-  got: %q",
+					want, got)
+			}
+		})
+	}
+}
+
 func TestMatchVLANTCI(t *testing.T) {
 	var tests = []struct {
 		desc string

--- a/ovs/matchparser.go
+++ b/ovs/matchparser.go
@@ -216,9 +216,9 @@ func parsePort(key string, value string, max int) (Match, error) {
 	case tpDST:
 		return TransportDestinationMaskedPort(uint16(values[0]), uint16(values[1])), nil
 	case udpSRC:
-		return UdpSourceMaskedPort(uint16(values[0]), uint16(values[1])), nil
+		return UDPSourceMaskedPort(uint16(values[0]), uint16(values[1])), nil
 	case udpDST:
-		return UdpDestinationMaskedPort(uint16(values[0]), uint16(values[1])), nil
+		return UDPDestinationMaskedPort(uint16(values[0]), uint16(values[1])), nil
 	}
 	// Return error if input is invalid
 	return nil, fmt.Errorf("no action matched for %s=%s", key, value)

--- a/ovs/matchparser.go
+++ b/ovs/matchparser.go
@@ -35,7 +35,7 @@ func parseMatch(key string, value string) (Match, error) {
 		return parseIntMatch(key, value, math.MaxUint8)
 	case ctZone:
 		return parseIntMatch(key, value, math.MaxUint16)
-	case tpSRC, tpDST:
+	case tpSRC, tpDST, udpSRC, udpDST:
 		return parsePort(key, value, math.MaxUint16)
 	case conjID:
 		return parseIntMatch(key, value, math.MaxUint32)
@@ -215,6 +215,10 @@ func parsePort(key string, value string, max int) (Match, error) {
 		return TransportSourceMaskedPort(uint16(values[0]), uint16(values[1])), nil
 	case tpDST:
 		return TransportDestinationMaskedPort(uint16(values[0]), uint16(values[1])), nil
+	case udpSRC:
+		return UdpSourceMaskedPort(uint16(values[0]), uint16(values[1])), nil
+	case udpDST:
+		return UdpDestinationMaskedPort(uint16(values[0]), uint16(values[1])), nil
 	}
 	// Return error if input is invalid
 	return nil, fmt.Errorf("no action matched for %s=%s", key, value)

--- a/ovs/matchparser_test.go
+++ b/ovs/matchparser_test.go
@@ -236,7 +236,7 @@ func Test_parseMatch(t *testing.T) {
 		},
 		{
 			s: "udp_dst=80",
-			m: UdpDestinationPort(80),
+			m: UDPDestinationPort(80),
 		},
 		{
 			s:       "udp_src=65536",
@@ -244,7 +244,7 @@ func Test_parseMatch(t *testing.T) {
 		},
 		{
 			s: "udp_src=80",
-			m: UdpSourcePort(80),
+			m: UDPSourcePort(80),
 		},
 		{
 			s:       "vlan_tci=",
@@ -515,7 +515,7 @@ func Test_parseMatch(t *testing.T) {
 		{
 			desc: "udp_dst 0xea60/0xffe0",
 			s:    "udp_dst=0xea60/0xffe0",
-			m:    UdpDestinationMaskedPort(0xea60, 0xffe0),
+			m:    UDPDestinationMaskedPort(0xea60, 0xffe0),
 		},
 		{
 			desc:    "udp_dst 0xea60/0xffe0/0xdddd",
@@ -540,7 +540,7 @@ func Test_parseMatch(t *testing.T) {
 		{
 			desc: "udp_src 0xea60/0xffe0",
 			s:    "udp_src=0xea60/0xffe0",
-			m:    UdpSourceMaskedPort(0xea60, 0xffe0),
+			m:    UDPSourceMaskedPort(0xea60, 0xffe0),
 		},
 		{
 			desc:    "udp_src 0xea60/0xffe0/0xdddd",

--- a/ovs/matchparser_test.go
+++ b/ovs/matchparser_test.go
@@ -231,6 +231,22 @@ func Test_parseMatch(t *testing.T) {
 			m: TransportSourcePort(80),
 		},
 		{
+			s:       "udp_dst=65536",
+			invalid: true,
+		},
+		{
+			s: "udp_dst=80",
+			m: UdpDestinationPort(80),
+		},
+		{
+			s:       "udp_src=65536",
+			invalid: true,
+		},
+		{
+			s: "udp_src=80",
+			m: UdpSourcePort(80),
+		},
+		{
 			s:       "vlan_tci=",
 			invalid: true,
 		},
@@ -479,6 +495,56 @@ func Test_parseMatch(t *testing.T) {
 		{
 			desc:    "tp_src 0xea60/0xffe0/0xdddd",
 			s:       "tp_src=0xea60/0xffe0/0xdddd",
+			invalid: true,
+		},
+		{
+			desc:    "udp_dst out of range 65536/0xffe0",
+			s:       "udp_dst=65536/0xffe0",
+			invalid: true,
+		},
+		{
+			desc:    "udp_dst out of range 0x10000/0xffe0",
+			s:       "udp_dst=0x10000/0xffe0",
+			invalid: true,
+		},
+		{
+			desc:    "udp_dst out of range 0xea60/0x10000",
+			s:       "udp_dst=0xea60/0x10000",
+			invalid: true,
+		},
+		{
+			desc: "udp_dst 0xea60/0xffe0",
+			s:    "udp_dst=0xea60/0xffe0",
+			m:    UdpDestinationMaskedPort(0xea60, 0xffe0),
+		},
+		{
+			desc:    "udp_dst 0xea60/0xffe0/0xdddd",
+			s:       "udp_dst=0xea60/0xffe0/0xdddd",
+			invalid: true,
+		},
+		{
+			desc:    "udp_src out of range 65536/0xffe0",
+			s:       "udp_src=65536/0xffe0",
+			invalid: true,
+		},
+		{
+			desc:    "udp_src out of range 0x10000/0xffe0",
+			s:       "udp_src=0x10000/0xffe0",
+			invalid: true,
+		},
+		{
+			desc:    "udp_src out of range 0xea60/0x10000",
+			s:       "udp_src=0xea60/0x10000",
+			invalid: true,
+		},
+		{
+			desc: "udp_src 0xea60/0xffe0",
+			s:    "udp_src=0xea60/0xffe0",
+			m:    UdpSourceMaskedPort(0xea60, 0xffe0),
+		},
+		{
+			desc:    "udp_src 0xea60/0xffe0/0xdddd",
+			s:       "udp_src=0xea60/0xffe0/0xdddd",
 			invalid: true,
 		},
 	}


### PR DESCRIPTION
Fixes #118.

This pull request adds types/functions which allow the matching of UDP source/destination ports. I basically just duplicated everything related to TCP and created UDP-specific variants.

The one thing which I did _not_ duplicate was this interface:

```go
// A TransportPortRanger represents a port range that can be expressed as an array of bitwise matches.
type TransportPortRanger interface {
	MaskedPorts() ([]Match, error)
}
```

I'm not sure if it makes sense to have both TCP and UDP port ranges match the same interface; if it doesn't make sense, then I'd be happy to create a `type UdpPortRanger interface { MaskedUdpPorts() ([]Match, error) }` to separate these.
I'm definitely looking for feedback on that matter.