### PR TITLE
Update InPortMatch GoString format

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,14 +29,13 @@ jobs:
         export GOPATH=/home/runner/work
         export PATH=$PATH:$GOPATH/bin
         mkdir $GOPATH/src $GOPATH/pkg $GOPATH/bin
-        go install honnef.co/go/tools/cmd/staticcheck@latest
+        go install honnef.co/go/tools/cmd/staticcheck@2020.2.1
         NEW=$GOPATH/src/github.com/digitalocean/go-openvswitch
         mkdir -p $NEW
         cp -r ./* $NEW
         cd $NEW
         go mod download
         go get golang.org/x/lint/golint
-        go get honnef.co/go/tools/cmd/staticcheck
         go get -d ./...
         echo "=========START LICENSE CHECK============"
         ./scripts/licensecheck.sh

--- a/ovs/match.go
+++ b/ovs/match.go
@@ -693,7 +693,7 @@ func (i *inPortMatch) MarshalText() ([]byte, error) {
 
 // GoString implements Match.
 func (i *inPortMatch) GoString() string {
-	return fmt.Sprintf("ovs.InPort(%q)", i.port)
+	return fmt.Sprintf("ovs.InPort(%d)", i.port)
 }
 
 // NeighborDiscoveryTarget matches packets with an IPv6 neighbor discovery target


### PR DESCRIPTION
The InPortMatch is using a %q for an int. Should be using a %d

Had to update the go.yml, it was attempting to install the latest version of staticcheck which was expecting go v1.19. This was causing failures during test run.