### PR TITLE
feat: Adds option to use different datapath

### DIFF
--- a/ovs/ovs.go
+++ b/ovs/ovs.go
@@ -41,6 +41,14 @@ const (
 	InterfaceTypeVXLAN    InterfaceType = "vxlan"
 )
 
+// A DatapathType is a datapath type recognized by Open vSwitch.
+type DataPathType string
+
+// DataPathType constants which can be used in OVS configurations.
+const (
+	DataPathTypeNetDev DataPathType = "netdev"
+)
+
 // A PortAction is a port actions to change the port characteristics of the
 // specific port through the ModPort API.
 type PortAction string

--- a/ovs/vswitch.go
+++ b/ovs/vswitch.go
@@ -201,7 +201,8 @@ func (v *VSwitchSetService) Bridge(bridge string, options BridgeOptions) error {
 // An BridgeOptions enables configuration of a bridge.
 type BridgeOptions struct {
 	// Protocols specifies the OpenFlow protocols the bridge should use.
-	Protocols []string
+	Protocols    []string
+	DataPathType DataPathType
 }
 
 // slice creates a string slice containing any non-zero option values from the
@@ -211,6 +212,10 @@ func (o BridgeOptions) slice() []string {
 
 	if len(o.Protocols) > 0 {
 		s = append(s, fmt.Sprintf("protocols=%s", strings.Join(o.Protocols, ",")))
+	}
+
+	if o.DataPathType != "" {
+		s = append(s, fmt.Sprintf("datapath_type=%s", o.DataPathType))
 	}
 
 	return s

--- a/ovs/vswitch_test.go
+++ b/ovs/vswitch_test.go
@@ -751,6 +751,13 @@ func TestBridgeOptions_slice(t *testing.T) {
 			},
 			out: []string{"protocols=OpenFlow10,OpenFlow11,OpenFlow12,OpenFlow13,OpenFlow14,OpenFlow15"},
 		},
+		{
+			desc: "with netdev datapath",
+			o: BridgeOptions{
+				DataPathType: DataPathTypeNetDev,
+			},
+			out: []string{"datapath_type=netdev"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

OVS can operate entirely in user space, provided the `datapath_type` parameter when creating bridge. This PR adds support for the netdev datapath. 

## Usage

```go
package main

import (
	"log"

	"github.com/digitalocean/go-openvswitch/ovs"
)

func main() {
	var ovsBridge string = "br0"

	ovsClient := ovs.New(
		ovs.Sudo(),
	)

	// sudo ovs-vsctl add-br br0
	if err := ovsClient.VSwitch.AddBridge(ovsBridge); err != nil {
		log.Fatalf("failed to add bridge: %v", err)
	}

	// sudo ovs-vsctl set bridge br0 datapath_type=netdev
	if err := ovsClient.VSwitch.Set.Bridge(ovsBridge, ovs.BridgeOptions{
		DataPathType: ovs.DataPathTypeNetDev,
	}); err != nil {
		log.Fatalf("failed to set bridge: %v", err)
	}

}

```

## Reference
- https://docs.openvswitch.org/en/latest/intro/install/userspace/