### PR TITLE
Add interface optional string for csum.

### DIFF
--- a/ovs/vswitch.go
+++ b/ovs/vswitch.go
@@ -274,6 +274,11 @@ type InterfaceOptions struct {
 	// tunneled traffic leaving this interface. Optionally it could be set to
 	// "flow" which expects the flow to set tunnel ID.
 	Key string
+
+	// Optionally compute encapsulation header (either GRE or UDP) checksums on
+	// outgoing packets. Default is false, set to true to enable. Checksums present
+	// on incoming packets will be validated regardless of this setting.
+	Csum string
 }
 
 // slice creates a string slice containing any non-zero option values from the
@@ -313,6 +318,10 @@ func (i InterfaceOptions) slice() []string {
 
 	if i.Key != "" {
 		s = append(s, fmt.Sprintf("options:key=%s", i.Key))
+	}
+
+	if i.Csum != "" {
+		s = append(s, fmt.Sprintf("options:csum=%s", i.Csum))
 	}
 
 	return s

--- a/ovs/vswitch_test.go
+++ b/ovs/vswitch_test.go
@@ -858,6 +858,21 @@ func TestInterfaceOptions_slice(t *testing.T) {
 			},
 		},
 		{
+			desc: "flow based VXLAN tunnel",
+			i: InterfaceOptions{
+				Type:     InterfaceTypeVXLAN,
+				RemoteIP: "flow",
+				Key:      "flow",
+				Csum:     "true",
+			},
+			out: []string{
+				"type=vxlan",
+				"options:remote_ip=flow",
+				"options:key=flow",
+				"options:csum=true",
+			},
+		},
+		{
 			desc: "all options",
 			i: InterfaceOptions{
 				Type:                 InterfaceTypePatch,


### PR DESCRIPTION
I needed csum configuration support in a project I'm working on, the specification is to set it as a string either true to enable or false to disable. I decided to implement as a string here so unless it is set, it won't pass the option to ovs-vsctl. I have tested the option in my project and it works.