### PR TITLE
ovsh: replace usage of unsafe package with binary marshaling and unmarshaling

### DIFF
--- a/ovsnl/client.go
+++ b/ovsnl/client.go
@@ -18,18 +18,9 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"unsafe"
 
 	"github.com/digitalocean/go-openvswitch/ovsnl/internal/ovsh"
 	"github.com/mdlayher/genetlink"
-)
-
-// Sizes of various structures, used in unsafe casts.
-const (
-	sizeofHeader = int(unsafe.Sizeof(ovsh.Header{}))
-
-	sizeofDPStats         = int(unsafe.Sizeof(ovsh.DPStats{}))
-	sizeofDPMegaflowStats = int(unsafe.Sizeof(ovsh.DPMegaflowStats{}))
 )
 
 // A Client is a Linux Open vSwitch generic netlink client.
@@ -115,21 +106,4 @@ func (c *Client) initFamily(f genetlink.Family) error {
 		// Unknown OVS netlink family, nothing we can do.
 		return fmt.Errorf("unknown OVS generic netlink family: %q", f.Name)
 	}
-}
-
-// headerBytes converts an ovsh.Header into a byte slice.
-func headerBytes(h ovsh.Header) []byte {
-	b := *(*[sizeofHeader]byte)(unsafe.Pointer(&h)) // #nosec G103
-	return b[:]
-}
-
-// parseHeader converts a byte slice into ovsh.Header.
-func parseHeader(b []byte) (ovsh.Header, error) {
-	// Verify that the byte slice is long enough before doing unsafe casts.
-	if l := len(b); l < sizeofHeader {
-		return ovsh.Header{}, fmt.Errorf("not enough data for OVS message header: %d bytes", l)
-	}
-
-	h := *(*ovsh.Header)(unsafe.Pointer(&b[:sizeofHeader][0])) // #nosec G103
-	return h, nil
 }

--- a/ovsnl/datapath_linux_test.go
+++ b/ovsnl/datapath_linux_test.go
@@ -13,12 +13,12 @@
 // limitations under the License.
 
 //go:build linux
+// +build linux
 
 package ovsnl
 
 import (
 	"testing"
-	"unsafe"
 
 	"github.com/digitalocean/go-openvswitch/ovsnl/internal/ovsh"
 	"github.com/google/go-cmp/cmp"
@@ -136,7 +136,8 @@ func TestClientDatapathListOK(t *testing.T) {
 			t.Fatalf("unexpected generic netlink command (-want +got):\n%s", diff)
 		}
 
-		h, err := parseHeader(greq.Data)
+		h := new(ovsh.Header)
+		err := ovsh.UnmarshalBinary(greq.Data, h)
 		if err != nil {
 			t.Fatalf("failed to parse OvS generic netlink header: %v", err)
 		}
@@ -147,7 +148,7 @@ func TestClientDatapathListOK(t *testing.T) {
 
 		return []genetlink.Message{
 			{
-				Data: mustMarshalDatapath(system),
+				Data: mustMarshalDatapath(t, system),
 			},
 		}, nil
 	}))
@@ -172,21 +173,23 @@ func TestClientDatapathListOK(t *testing.T) {
 	}
 }
 
-func mustMarshalDatapath(dp Datapath) []byte {
-	h := ovsh.Header{
+func mustMarshalDatapath(t *testing.T, dp Datapath) []byte {
+	hb, err := ovsh.MarshalBinary(&ovsh.Header{
 		Ifindex: int32(dp.Index),
+	})
+	if err != nil {
+		t.Fatal(t)
 	}
 
-	hb := headerBytes(h)
-
-	s := ovsh.DPStats{
+	sb, err := ovsh.MarshalBinary(&ovsh.DPStats{
 		Hit:    dp.Stats.Hit,
 		Missed: dp.Stats.Missed,
 		Lost:   dp.Stats.Lost,
 		Flows:  dp.Stats.Flows,
+	})
+	if err != nil {
+		t.Fatal(t)
 	}
-
-	sb := *(*[sizeofDPStats]byte)(unsafe.Pointer(&s)) // #nosec G103
 
 	ms := ovsh.DPMegaflowStats{
 		Mask_hit: dp.MegaflowStats.MaskHits,
@@ -194,7 +197,10 @@ func mustMarshalDatapath(dp Datapath) []byte {
 		// Pad already set to zero.
 	}
 
-	msb := *(*[sizeofDPMegaflowStats]byte)(unsafe.Pointer(&ms)) // #nosec G103
+	msb, err := ovsh.MarshalBinary(&ms)
+	if err != nil {
+		t.Fatal(t)
+	}
 
 	ab := mustMarshalAttributes([]netlink.Attribute{
 		{
@@ -207,7 +213,7 @@ func mustMarshalDatapath(dp Datapath) []byte {
 		},
 		{
 			Type: ovsh.DpAttrStats,
-			Data: sb[:],
+			Data: sb,
 		},
 		{
 			Type: ovsh.DpAttrMegaflowStats,

--- a/ovsnl/internal/ovsh/binary.go
+++ b/ovsnl/internal/ovsh/binary.go
@@ -1,0 +1,39 @@
+// Copyright 2017 DigitalOcean.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ovsh
+
+import (
+	"bytes"
+	"encoding/binary"
+)
+
+// ovsTypes defines a type set of the types defined in struct.go
+type ovsTypes interface {
+	Header | DPStats | DPMegaflowStats | VportStats | FlowStats
+}
+
+// MarshalBinary is a generic binary marshaling function for the type defined in struct.go
+func MarshalBinary[T ovsTypes](data *T) ([]byte, error) {
+	var buf bytes.Buffer
+	err := binary.Write(&buf, binary.NativeEndian, data)
+	return buf.Bytes(), err
+}
+
+// UnmarshalBinary is a generic binary unmarshaling function for the type defined in struct.go
+func UnmarshalBinary[T ovsTypes](data []byte, dst *T) error {
+	*dst = *new(T) // reset the contents, just to be safe
+	buf := bytes.NewBuffer(data)
+	return binary.Read(buf, binary.NativeEndian, dst)
+}

--- a/ovsnl/internal/ovsh/binary.go
+++ b/ovsnl/internal/ovsh/binary.go
@@ -17,6 +17,7 @@ package ovsh
 import (
 	"bytes"
 	"encoding/binary"
+	"fmt"
 )
 
 // ovsTypes defines a type set of the types defined in struct.go
@@ -33,6 +34,11 @@ func MarshalBinary[T ovsTypes](data *T) ([]byte, error) {
 
 // UnmarshalBinary is a generic binary unmarshaling function for the type defined in struct.go
 func UnmarshalBinary[T ovsTypes](data []byte, dst *T) error {
+	// Verify that the byte slice has enough data before unmarshaling.
+	if want, got := binary.Size(*dst), len(data); got < want {
+		return fmt.Errorf("unexpected size of struct %T, want at least %d, got %d", *dst, want, got)
+	}
+
 	*dst = *new(T) // reset the contents, just to be safe
 	buf := bytes.NewBuffer(data)
 	return binary.Read(buf, binary.NativeEndian, dst)


### PR DESCRIPTION
This addresses the usage of unsafe for mapping the byte slices of data to the well-defined Go structs. 